### PR TITLE
✨ [FEAT][BE] 매크로 API 1차 

### DIFF
--- a/hyo-banking-be/.gitignore
+++ b/hyo-banking-be/.gitignore
@@ -37,5 +37,7 @@ out/
 ### VS Code ###
 .vscode/
 
-
+/env/
+/.env
+/hyo.sql
 .env

--- a/hyo-banking-be/env
+++ b/hyo-banking-be/env
@@ -1,0 +1,3 @@
+DB_URL=jdbc:mysql://localhost:3306/hyo_banking_db?autoReconnect=true
+DB_USERNAME=hyo
+DB_PASSWORD=1234

--- a/hyo-banking-be/env
+++ b/hyo-banking-be/env
@@ -1,3 +1,0 @@
-DB_URL=jdbc:mysql://localhost:3306/hyo_banking_db?autoReconnect=true
-DB_USERNAME=hyo
-DB_PASSWORD=1234

--- a/hyo-banking-be/hyo.sql
+++ b/hyo-banking-be/hyo.sql
@@ -1,0 +1,8 @@
+DROP DATABASE IF EXISTS hyo_banking_db;
+CREATE DATABASE hyo_banking_db;
+USE hyo_banking_db;
+
+DROP USER IF EXISTS 'hyo'@'localhost';
+CREATE USER 'hyo'@'localhost' IDENTIFIED BY '1234';
+GRANT ALL PRIVILEGES ON hyo_banking_db.* TO 'hyo'@'localhost';
+FLUSH PRIVILEGES;

--- a/hyo-banking-be/hyo.sql
+++ b/hyo-banking-be/hyo.sql
@@ -1,8 +1,0 @@
-DROP DATABASE IF EXISTS hyo_banking_db;
-CREATE DATABASE hyo_banking_db;
-USE hyo_banking_db;
-
-DROP USER IF EXISTS 'hyo'@'localhost';
-CREATE USER 'hyo'@'localhost' IDENTIFIED BY '1234';
-GRANT ALL PRIVILEGES ON hyo_banking_db.* TO 'hyo'@'localhost';
-FLUSH PRIVILEGES;

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/exception/GlobalExceptionHandler.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/exception/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package org.atmgigi.hyobankingbe.exception;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+// REST 컨트롤러 전역에서 발생하는 예외를 가로채 처리
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 리소스 없음: 404 NOT FOUND
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<?> notFound(NoSuchElementException e) {
+        // {"error": "메시지"} 형태로 응답
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+    }
+
+    // 잘못된 요청: 400 BAD REQUEST
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<?> badRequest(NoSuchElementException e) {
+        // {"error": "메시지"} 형태로 응답
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+    }
+
+    // 상태 충돌 (비즈니스 제약 위반 등): 409 CONFLICT
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<?> conflict(IllegalStateException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
+    }
+
+    // 데이터 무결성 위반(UNIQUE, FK 등)" 409 CONFLICT
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<?> conflict2(DataIntegrityViolationException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", "DATA_INTEGRITY"));
+    }
+
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/controller/ExecutionController.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/controller/ExecutionController.java
@@ -1,5 +1,6 @@
 package org.atmgigi.hyobankingbe.macro.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.atmgigi.hyobankingbe.macro.domain.ExecutionStatus;
 import org.atmgigi.hyobankingbe.macro.domain.MacroStatus;
 import org.atmgigi.hyobankingbe.macro.dto.ExecutionDtos;
@@ -20,15 +21,11 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/executions")
+@RequiredArgsConstructor
 public class ExecutionController {
 
     private final ExecutionService service;
     private final MacroExecutionRepository repo;
-
-    public ExecutionController(ExecutionService service, MacroExecutionRepository repo) {
-        this.service = service;
-        this.repo = repo;
-    }
 
     // 실행 시작
     @PostMapping

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/controller/ExecutionController.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/controller/ExecutionController.java
@@ -1,0 +1,62 @@
+package org.atmgigi.hyobankingbe.macro.controller;
+
+import org.atmgigi.hyobankingbe.macro.domain.ExecutionStatus;
+import org.atmgigi.hyobankingbe.macro.domain.MacroStatus;
+import org.atmgigi.hyobankingbe.macro.dto.ExecutionDtos;
+import org.atmgigi.hyobankingbe.macro.entity.MacroExecution;
+import org.atmgigi.hyobankingbe.macro.repository.MacroExecutionRepository;
+import org.atmgigi.hyobankingbe.macro.service.ExecutionService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/executions")
+public class ExecutionController {
+
+    private final ExecutionService service;
+    private final MacroExecutionRepository repo;
+
+    public ExecutionController(ExecutionService service, MacroExecutionRepository repo) {
+        this.service = service;
+        this.repo = repo;
+    }
+
+    // 실행 시작
+    @PostMapping
+    public ResponseEntity<?> start(@RequestBody ExecutionDtos.StartExecReq req) {
+        MacroExecution ex = service.start(req.macro_id(), req.qr_token());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(Map.of("id", ex.getId(), "status", ex.getStatus()));
+    }
+
+    // 실행 단건 조회
+    @GetMapping("/{id}")
+    public MacroExecution get(@PathVariable Long id) {
+        return repo.findById(id).orElseThrow();
+    }
+
+    // 실행 목록 조회
+    @GetMapping
+    public Page<MacroExecution> list(@RequestParam Long macroId,
+                                     @RequestParam(required = false) ExecutionStatus status,
+                                     @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+                                     @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
+                                     @RequestParam(defaultValue = "0") int page,
+                                     @RequestParam(defaultValue = "20") int size) {
+        Pageable p = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        LocalDateTime f = (from == null) ? LocalDateTime.MIN : from;
+        LocalDateTime t = (to == null) ? LocalDateTime.MAX : to;
+        if (status == null) return repo.findByMacro_IdAndStartedAtBetween(macroId, f, t, p);
+        return repo.findByMacro_IdAndStatusAndStartedAtBetween(macroId, status, f, t, p);
+    }
+
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/controller/MacroController.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/controller/MacroController.java
@@ -1,5 +1,6 @@
 package org.atmgigi.hyobankingbe.macro.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.atmgigi.hyobankingbe.macro.domain.MacroStatus;
 import org.atmgigi.hyobankingbe.macro.dto.MacroDtos;
 import org.atmgigi.hyobankingbe.macro.entity.Macro;
@@ -20,15 +21,11 @@ import java.util.List;
 // 매크로 + 스텝 API
 @RestController
 @RequestMapping("/macros")
+@RequiredArgsConstructor
 public class MacroController {
 
     private final MacroService service;
     private final MacroRepository repo;
-
-    public MacroController(MacroService service, MacroRepository repo) {
-        this.service = service;
-        this.repo = repo;
-    }
 
     // 매크로 생성
     @PostMapping

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/controller/MacroController.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/controller/MacroController.java
@@ -1,0 +1,115 @@
+package org.atmgigi.hyobankingbe.macro.controller;
+
+import org.atmgigi.hyobankingbe.macro.domain.MacroStatus;
+import org.atmgigi.hyobankingbe.macro.dto.MacroDtos;
+import org.atmgigi.hyobankingbe.macro.entity.Macro;
+import org.atmgigi.hyobankingbe.macro.dto.MacroDtos.*;
+import org.atmgigi.hyobankingbe.macro.entity.MacroStep;
+import org.atmgigi.hyobankingbe.macro.repository.MacroRepository;
+import org.atmgigi.hyobankingbe.macro.service.MacroService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+// 매크로 + 스텝 API
+@RestController
+@RequestMapping("/macros")
+public class MacroController {
+
+    private final MacroService service;
+    private final MacroRepository repo;
+
+    public MacroController(MacroService service, MacroRepository repo) {
+        this.service = service;
+        this.repo = repo;
+    }
+
+    // 매크로 생성
+    @PostMapping
+    public ResponseEntity<Macro> create(@RequestBody CreateMacroReq req) {
+        Macro m = service.create(req.userId(), req.name());
+        return ResponseEntity.status(HttpStatus.CREATED).body(m);
+    }
+
+    // 매크로 목록 조회
+    @GetMapping
+    public Page<Macro> list(@RequestParam Long userId,
+                            @RequestParam(required = false) MacroStatus status,
+                            @RequestParam(defaultValue = "0") int page,
+                            @RequestParam(defaultValue = "20") int size) {
+        Pageable p = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        return (status == null)
+                ? repo.findByUserId(userId, p)
+                : repo.findByUserIdAndStatus(userId, status, p);
+    }
+
+    // 매크로 단건 조회
+    @GetMapping("/{id}")
+    public Macro get(@PathVariable Long id) {
+        return service.get(id);
+    }
+
+    // 매크로 수정
+    @PatchMapping("/{id}")
+    public Macro patch(@PathVariable Long id, @RequestBody PatchMacroReq req) {
+        return service.patch(id, req.name(), req.status());
+    }
+
+    // 매크로 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.deleteIfDraft(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 단계 추가
+    @PostMapping("/{id}/steps")
+    public ResponseEntity<MacroStep> addStep(@PathVariable Long id, @RequestBody StepReq req) {
+        MacroStep s = MacroStep.builder()
+                .stepOrder(req.stepOrder())
+                .stepType(req.stepType())
+                .amount(req.amount()==null?null:req.amount().longValue())
+                .currencyCode(req.currencyCode())
+                .accountFromId(req.accountFromId())
+                .accountToId(req.accountToId())
+                .note(req.note())
+                .build();
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.addStep(id,s));
+    }
+
+    // 단계 업서트
+    @PutMapping("/{id}/steps/{order}")
+    public MacroStep upsertStep(@PathVariable Long id,
+                                @PathVariable Integer order,
+                                @RequestBody StepReq req) {
+        MacroStep s = MacroStep.builder()
+                .stepType(req.stepType())
+                .amount(req.amount() == null ? null : req.amount().longValue())
+                .currencyCode(req.currencyCode())
+                .accountFromId(req.accountFromId())
+                .accountToId(req.accountToId())
+                .note(req.note())
+                .build();
+        return service.upsertStep(id,order,s);
+    }
+
+    // 단계 목록 조회
+    @GetMapping("/{id}/steps")
+    public List<MacroStep> listSTeps(@PathVariable Long id){
+        return service.listSteps(id);
+    }
+
+    // 단계 삭제
+    @DeleteMapping("/{id}/steps/{order}")
+    public ResponseEntity<Void> deleteStep(@PathVariable Long id, @PathVariable Integer order) {
+        service.deleteStep(id,order);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/controller/QrTokenController.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/controller/QrTokenController.java
@@ -1,5 +1,6 @@
 package org.atmgigi.hyobankingbe.macro.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.atmgigi.hyobankingbe.macro.entity.MacroQrToken;
 import org.atmgigi.hyobankingbe.macro.service.QrTokenService;
 import org.springframework.http.HttpStatus;
@@ -13,13 +14,10 @@ import java.time.Duration;
 import java.util.Map;
 
 @RestController
+@RequiredArgsConstructor
 public class QrTokenController {
 
     private final QrTokenService service;
-
-    public QrTokenController(QrTokenService service) {
-        this.service = service;
-    }
 
     // QR 토큰 생성
     @PostMapping("/macros/{id}/qr-tokens")

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/controller/QrTokenController.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/controller/QrTokenController.java
@@ -1,0 +1,49 @@
+package org.atmgigi.hyobankingbe.macro.controller;
+
+import org.atmgigi.hyobankingbe.macro.entity.MacroQrToken;
+import org.atmgigi.hyobankingbe.macro.service.QrTokenService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+import java.util.Map;
+
+@RestController
+public class QrTokenController {
+
+    private final QrTokenService service;
+
+    public QrTokenController(QrTokenService service) {
+        this.service = service;
+    }
+
+    // QR 토큰 생성
+    @PostMapping("/macros/{id}/qr-tokens")
+    public ResponseEntity<Map<String, Object>> create(@PathVariable Long id) {
+        MacroQrToken t = service.create(id, Duration.ofMinutes(5));
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("token",t.getToken(),"expires_at",t.getExpiresAt()));
+    }
+
+    // QR 토큰 무효화
+    @PostMapping("/qr-tokens/{token}/invalidate")
+    public ResponseEntity<Void> invalidate(@PathVariable String token) {
+        service.invalidate(token);
+        return ResponseEntity.noContent().build();
+    }
+
+    // QR 토큰 조회
+    @GetMapping("/qr-tokens/{token}")
+    public ResponseEntity<?> get(@PathVariable String token) {
+        return service.find(token)
+                .<ResponseEntity<?>>map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+
+
+
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/domain/ExecutionStatus.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/domain/ExecutionStatus.java
@@ -1,0 +1,9 @@
+package org.atmgigi.hyobankingbe.macro.domain;
+
+public enum ExecutionStatus {
+    PENDING, // 실행 요청만 들어온 상태, 아직 시작 x
+    RUNNING, // 실제로 단계들이 실행 중인 상태
+    SUCCEEDED, // 모든 단계가 성공적으로 끝난 상태
+    FAILED // 실행 중 오류가 발생한 상태
+}
+

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/domain/MacroStatus.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/domain/MacroStatus.java
@@ -1,0 +1,7 @@
+package org.atmgigi.hyobankingbe.macro.domain;
+
+public enum MacroStatus { //한 매크로의 현재 상태
+    ACTIVE,//현재 사용 가능하고 실행 가능한 상태
+    DRAFT, // 작성 중, 아직 확정되지 않은 상태
+    INACTIVE, // 비활성화, 더 이상 실행되지 않음
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/domain/StepType.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/domain/StepType.java
@@ -1,0 +1,8 @@
+package org.atmgigi.hyobankingbe.macro.domain;
+
+public enum StepType {
+    BALANCE_CHECK, //잔액 확인 (금액 필요 X, 출금 계좌 필요)
+    WITHDRAW, //출금 (from 계좌 필요, 금액 필요)
+    DEPOSIT, //입금 (to 계좌 필요, 금액 필요)
+    TRANSFER //이체 (from + to 계좌)
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/dto/ExecutionDtos.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/dto/ExecutionDtos.java
@@ -1,0 +1,9 @@
+package org.atmgigi.hyobankingbe.macro.dto;
+
+//실행 관련 요청 DTO
+public class ExecutionDtos {
+
+    //실행 시작 요청
+    public record StartExecReq(Long macro_id, String qr_token) {}
+
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/dto/MacroDtos.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/dto/MacroDtos.java
@@ -1,0 +1,28 @@
+package org.atmgigi.hyobankingbe.macro.dto;
+
+import org.atmgigi.hyobankingbe.macro.domain.MacroStatus;
+import org.atmgigi.hyobankingbe.macro.domain.StepType;
+
+// 매크로 생성 요청 바디용 DTO들을 감싸는 클래스 (내부에 record 타입들을 정의)
+public class MacroDtos {
+
+    // 매크로 생성 요청 바디용 DTO: { "userId": 1, "name": "월말 이체" }
+    public record CreateMacroReq(Long userId, String name) {}
+
+    // 매크로 수정(PATCH) 요청 바디용 DTO: { "name": "...", "status" : "ACTIVE" }
+    public record PatchMacroReq(String name, MacroStatus status) {}
+
+    // 스텝 생성/수정 요청
+    public record StepReq(
+            Integer stepOrder, // 실행 순서 (POST에서만 사용)
+            StepType stepType, // BALANCE_CHECK / WITHDRAW / DEPOSIT / TRANSFER
+            Long amount, // 금액 (nullable)
+            String currencyCode, // 통화 (예: KRW)
+            Long accountFromId, // 출금 계좌 (nullable)
+            Long accountToId, // 입금 계좌 (nullable)
+            String note // 비고 (nullable)
+    ) {}
+
+}
+
+

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/entity/Macro.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/entity/Macro.java
@@ -1,0 +1,40 @@
+package org.atmgigi.hyobankingbe.macro.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.atmgigi.hyobankingbe.macro.domain.MacroStatus;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "macro")
+@Getter
+@Setter              // ← getter/setter 자동 생성
+@NoArgsConstructor           // ← 기본 생성자
+@AllArgsConstructor          // ← 전체 필드 생성자
+@Builder                     // ← 빌더 패턴 지원
+public class Macro {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK, 자동 증가
+
+    @Column(nullable = false)
+    private Long userId; //어떤 사용자의 매크로인지
+
+    @Column(nullable = false)
+    private String name; //매크로 이름
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MacroStatus status; // ACTIVE / DRAFT / INACTIVE
+
+    @CreationTimestamp
+    private LocalDateTime createdAt; // 생성 시각 자동 기록
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt; //수정 시각 자동 갱신
+
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/entity/MacroExecution.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/entity/MacroExecution.java
@@ -3,6 +3,8 @@ package org.atmgigi.hyobankingbe.macro.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.atmgigi.hyobankingbe.macro.domain.ExecutionStatus;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -39,9 +41,11 @@ public class MacroExecution {
     private LocalDateTime finishedAt;
 
     @Column(nullable = false, insertable = false, updatable = false)
+    @CreationTimestamp
     private LocalDateTime createdAt;
 
     @Column(nullable = false, insertable = false, updatable = false)
+    @UpdateTimestamp
     private LocalDateTime updatedAt;
 
 }

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/entity/MacroExecution.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/entity/MacroExecution.java
@@ -1,0 +1,47 @@
+package org.atmgigi.hyobankingbe.macro.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.atmgigi.hyobankingbe.macro.domain.ExecutionStatus;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "macro_execution")
+@Getter
+@Setter   // ← 롬복 덕분에 getter/setter 자동 생성
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MacroExecution {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY) // 어떤 매크로 실행인지
+    @JoinColumn(name = "macro_id", nullable = false)
+    private Macro macro;
+
+    @OneToOne(fetch = FetchType.LAZY) // 토큰은 1회용 -> 실행과 1:1
+    @JoinColumn(name = "qr_token_id" , nullable = false, unique = true)
+    private MacroQrToken qrToken;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ExecutionStatus status; // Pending, RUNNING, SUCCEEDED, FAILED
+
+    private String errorMessage;
+
+    private String errorCode;
+
+    private LocalDateTime startedAt;
+    private LocalDateTime finishedAt;
+
+    @Column(nullable = false, insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false, insertable = false, updatable = false)
+    private LocalDateTime updatedAt;
+
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/entity/MacroQrToken.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/entity/MacroQrToken.java
@@ -2,6 +2,8 @@ package org.atmgigi.hyobankingbe.macro.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -31,9 +33,11 @@ public class MacroQrToken {
     private LocalDateTime usedAt; // 사용된 시각 (한 번 쓰면 채움)
 
     @Column(nullable = false, insertable = false, updatable = false)
+    @CreationTimestamp
     private LocalDateTime createdAt; // DB에서 자동 세팅
 
     @Column(nullable = false, insertable = false, updatable = false)
+    @UpdateTimestamp
     private LocalDateTime updatedAt; // DB에서 자동 세팅
 
 }

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/entity/MacroQrToken.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/entity/MacroQrToken.java
@@ -1,0 +1,39 @@
+package org.atmgigi.hyobankingbe.macro.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "macro_qr_token")
+@Getter
+@Setter   // ← 롬복 덕분에 getter/setter 자동 생성
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MacroQrToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "macro_id", nullable = false)
+    private Macro macro; // 어떤 매크로의 토큰인지
+
+    @Column(nullable = false, unique = true)
+    private String token; // QR 토큰 값 (UUID)
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt; // 만료 시각
+
+    private LocalDateTime usedAt; // 사용된 시각 (한 번 쓰면 채움)
+
+    @Column(nullable = false, insertable = false, updatable = false)
+    private LocalDateTime createdAt; // DB에서 자동 세팅
+
+    @Column(nullable = false, insertable = false, updatable = false)
+    private LocalDateTime updatedAt; // DB에서 자동 세팅
+
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/entity/MacroStep.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/entity/MacroStep.java
@@ -1,0 +1,41 @@
+package org.atmgigi.hyobankingbe.macro.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.atmgigi.hyobankingbe.macro.domain.StepType;
+
+@Entity
+@Table(name = "macro_step")
+@Getter
+@Setter   // ← 롬복 덕분에 getter/setter 자동 생성
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MacroStep {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "macro_id", nullable = false)
+    private Macro macro; // 어느 매크로에 속하는 단계인지 (FK)
+
+    @Column(nullable = false)
+    private Integer stepOrder; // 실행 순서 (1, 2, 3..)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private StepType stepType;        // BALANCE_CHECK / WITHDRAW /...
+
+    private Long accountFromId; // 출금 계좌 (nullable)
+
+    private Long accountToId; // 입금 계좌 (nullable)
+
+    private Long amount; // 금액 (nullable)
+
+    private String currencyCode; // 통화 (예: KRW)
+
+    private String note; //비고 설명
+
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/repository/MacroExecutionRepository.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/repository/MacroExecutionRepository.java
@@ -1,0 +1,30 @@
+package org.atmgigi.hyobankingbe.macro.repository;
+
+import org.atmgigi.hyobankingbe.macro.domain.ExecutionStatus;
+import org.atmgigi.hyobankingbe.macro.entity.MacroExecution;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+
+//매크로 실행(MacroExecution) 레포지토리
+public interface MacroExecutionRepository extends JpaRepository<MacroExecution, Long> {
+
+    // 특정 매크로 ID 기준 실행 목록
+    Page<MacroExecution> findByMacro_Id(Long macroId, Pageable p);
+
+    // 특정 매크로 ID + 상태별 실행 목록
+    Page<MacroExecution> findByMacro_IdAndStatus(Long macroId, ExecutionStatus status, Pageable p);
+
+    // 특정 매크로 ID + 상태 + 기간별 실행 목록
+    Page<MacroExecution> findByMacro_IdAndStatusAndStartedAtBetween(
+            Long macroId, ExecutionStatus status, LocalDateTime from, LocalDateTime to, Pageable p
+    );
+
+    // 특정 매크로 ID + 기간별 실행 목록
+    Page<MacroExecution> findByMacro_IdAndStartedAtBetween(
+            Long macroId, LocalDateTime from, LocalDateTime to, Pageable p
+    );
+
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/repository/MacroQrTokenRepository.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/repository/MacroQrTokenRepository.java
@@ -1,0 +1,17 @@
+package org.atmgigi.hyobankingbe.macro.repository;
+
+import org.atmgigi.hyobankingbe.macro.entity.MacroQrToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+//매크로 QR 토근(MacroQrToken) 레포지토리
+public interface MacroQrTokenRepository extends JpaRepository<MacroQrToken, Long> {
+
+    // 토큰 문자열 값으로 조회
+    Optional<MacroQrToken> findByToken(String token);
+
+    // 특정 매크로 ID + 토큰 문자열로 조회
+    Optional<MacroQrToken> findByMacro_IdAndToken(Long macroId, String token);
+
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/repository/MacroRepository.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/repository/MacroRepository.java
@@ -1,0 +1,17 @@
+package org.atmgigi.hyobankingbe.macro.repository;
+
+import org.atmgigi.hyobankingbe.macro.domain.MacroStatus;
+import org.atmgigi.hyobankingbe.macro.entity.Macro;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// 매크로 (Macro) 기본 CRUD + 조회용 레포지토리
+public interface MacroRepository extends JpaRepository<Macro, Long> {
+
+    // 특정 userId로 매크로 목록 조회 (페이징 지원)
+    Page<Macro> findByUserId(Long userId, Pageable p);
+
+    // 특정 userId + 상태 (MacroStatus)로 매크로 목록 조회 (페이징 지원)
+    Page<Macro> findByUserIdAndStatus(Long userId, MacroStatus status, Pageable p);
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/repository/MacroStepRepository.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/repository/MacroStepRepository.java
@@ -1,0 +1,20 @@
+package org.atmgigi.hyobankingbe.macro.repository;
+
+import org.atmgigi.hyobankingbe.macro.entity.MacroStep;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MacroStepRepository extends JpaRepository<MacroStep, Long> {
+
+    // 특정 매크로에 속한 단계들을 순서(stepOrder)대로 조회
+    List<MacroStep> findByMacro_IdOrderByStepOrderAsc(Long macroId);
+
+    // 특정 매크로 + 특정 단계 번호(stepOrder)로 단일 단계 조회
+    Optional<MacroStep> findByMacro_IdAndStepOrder(Long macroId, Integer stepOrder);
+
+    // 특정 매크로 + 특정 단계 번호(stepOrder)로 삭제
+    void deleteByMacro_IdAndStepOrder(Long macroId, Integer stepOrder);
+
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/service/ExecutionService.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/service/ExecutionService.java
@@ -1,0 +1,59 @@
+package org.atmgigi.hyobankingbe.macro.service;
+
+import org.atmgigi.hyobankingbe.macro.domain.ExecutionStatus;
+import org.atmgigi.hyobankingbe.macro.entity.MacroExecution;
+import org.atmgigi.hyobankingbe.macro.entity.MacroQrToken;
+import org.atmgigi.hyobankingbe.macro.repository.MacroExecutionRepository;
+import org.atmgigi.hyobankingbe.macro.repository.MacroQrTokenRepository;
+import org.atmgigi.hyobankingbe.macro.repository.MacroRepository;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+public class ExecutionService {
+
+    private final MacroExecutionRepository execRepo;
+    private final MacroQrTokenRepository tokenRepo;
+    private final MacroRepository macroRepo;
+
+    public ExecutionService(MacroExecutionRepository execRepo, MacroQrTokenRepository tokenRepo, MacroRepository macroRepo) {
+        this.execRepo = execRepo;
+        this.tokenRepo = tokenRepo;
+        this.macroRepo = macroRepo;
+    }
+
+    // 실행 세션 시작 (토큰 1회성 보장)
+    @Transactional
+    public MacroExecution start(Long macroId, String qrTokenString) {
+        // 1) (macro_id, token)으로 토큰 조회
+        MacroQrToken token = tokenRepo.findByMacro_IdAndToken(macroId,qrTokenString)
+                .orElseThrow(()-> new IllegalArgumentException("TOKEN_NOT_FOUND"));
+
+        // 2) 유효성 (만료/사용됨) 체크
+        LocalDateTime now = LocalDateTime.now();
+        if (token.getUsedAt() != null || token.getExpiresAt().isBefore(now)){
+            throw new IllegalStateException("TOKEN_EXPIRED_OR_USED");
+        }
+
+        // 3) 사용 처리 (재사용 방지)
+        token.setUsedAt(now);
+
+        try {
+            // 4) 실행 엔티티 생성 (토큰과 매크로는 엔티티로 연결)
+            MacroExecution ex = MacroExecution.builder()
+                    .macro(macroRepo.getReferenceById(macroId)) // // FK: macro_id
+                    .qrToken(token) // FK: qr_token_id (unique)
+                    .status(ExecutionStatus.PENDING)
+                    .build();
+
+            return execRepo.save(ex);
+        } catch (DataIntegrityViolationException dup) {
+            // 5) UNIQUE 제약 위반 시 (같은 토큰 중복 사용)
+            throw new IllegalStateException("TOKEN_ALREADY_USED");
+        }
+    }
+
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/service/MacroService.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/service/MacroService.java
@@ -1,0 +1,127 @@
+package org.atmgigi.hyobankingbe.macro.service;
+
+import org.atmgigi.hyobankingbe.macro.domain.MacroStatus;
+import org.atmgigi.hyobankingbe.macro.domain.StepType;
+import org.atmgigi.hyobankingbe.macro.entity.Macro;
+import org.atmgigi.hyobankingbe.macro.entity.MacroStep;
+import org.atmgigi.hyobankingbe.macro.repository.MacroRepository;
+import org.atmgigi.hyobankingbe.macro.repository.MacroStepRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+// 매크로와 매크로 단계(MacroStep) 관련 비즈니스 로직 처리
+@Service
+public class MacroService {
+    private final MacroRepository macroRepo;
+    private final MacroStepRepository stepRepo;
+
+    public MacroService(MacroRepository macroRepo, MacroStepRepository stepRepo) {
+        this.macroRepo = macroRepo;
+        this.stepRepo = stepRepo;
+    }
+
+    // 매크로 생성 (userId, name 받아서 상태는 기본 ACTIVE)
+    @Transactional
+    public Macro create(Long userId, String name) {
+        Macro m = Macro.builder()
+                .userId(userId)
+                .name(name)
+                .status(MacroStatus.ACTIVE)
+                .build();
+        return macroRepo.save(m);
+    }
+
+    // 매크로 단건 조회 (없으면 예외 발생)
+    public Macro get(Long id) {
+        return macroRepo.findById(id)
+                .orElseThrow(()-> new NoSuchElementException("MACRO_NOT_FOUND"));
+    }
+
+    // 매크로 수정 (name, status 일부만 업데이트 가능)
+    @Transactional
+    public Macro patch(Long id, String name, MacroStatus status) {
+        Macro m = get(id);
+        if (name != null) m.setName(name);
+        if (status != null) m.setStatus(status);
+        return macroRepo.save(m);
+    }
+
+    // 매크로 삭제 (DRAFT 상태일 때만 가능)
+    @Transactional
+    public void deleteIfDraft(Long id) {
+        Macro m = get(id);
+        if (m.getStatus() != MacroStatus.DRAFT) {
+            throw new IllegalStateException("ONLY_DRAFT_DELETABLE");
+        }
+        macroRepo.deleteById(id);
+    }
+
+    // 단계 유효성 검증 (StepType별로 필드 조건 확인)
+    private void validateStep(MacroStep s) {
+        StepType t = s.getStepType();
+        switch (t) {
+            case BALANCE_CHECK -> {
+                if (s.getAmount() != null) throw new IllegalArgumentException("BALANCE_CHECK.amount must be null");
+                if (s.getAccountFromId() == null) throw new IllegalArgumentException("BALANCE_CHECK.from required");
+                if (s.getAccountToId() != null) throw new IllegalArgumentException("BALANCE_CHECK.to must be null");
+            }
+            case WITHDRAW -> {
+                if (s.getAccountFromId() == null) throw new IllegalArgumentException("WITHDRAW.from required");
+                if (s.getAccountToId() != null) throw new IllegalArgumentException("WITHDRAW.to must be null");
+                if (s.getAmount() == null || s.getCurrencyCode() == null)
+                    throw new IllegalArgumentException("WITHDRAW amount/currency required");
+            }
+            case DEPOSIT -> {
+                if (s.getAccountToId() == null) throw new IllegalArgumentException("DEPOSIT.to required");
+                if (s.getAccountFromId() != null) throw new IllegalArgumentException("DEPOSIT.from must be null");
+                if (s.getAmount() == null || s.getCurrencyCode() == null)
+                    throw new IllegalArgumentException("DEPOSIT amount/currency required");
+            }
+            case TRANSFER -> {
+                if (s.getAccountFromId() == null || s.getAccountToId() == null)
+                    throw new IllegalArgumentException("TRANSFER from/to required");
+                if (s.getAmount() == null || s.getCurrencyCode() == null)
+                    throw new IllegalArgumentException("TRANSFER amount/currency required");
+            }
+        }
+    }
+
+    // 단계 추가 (POST)
+    @Transactional
+    public MacroStep addStep(Long macroId, MacroStep s) {
+        s.setMacro(macroRepo.getReferenceById(macroId));  // // FK: macro_id
+        validateStep(s);
+        return stepRepo.save(s);
+    }
+
+    // 단계 업서트 (있으면 수정, 없으면 시규)
+    @Transactional
+    public MacroStep upsertStep(Long macroId,  Integer order, MacroStep s) {
+        s.setMacro(macroRepo.getReferenceById(macroId)); // FK: macro_id
+        s.setStepOrder(order);
+        validateStep(s);
+
+        return stepRepo.findByMacro_IdAndStepOrder(macroId,order)
+                .map(old -> {
+                    s.setId(old.getId());
+                    return stepRepo.save(s); //기존 행 업데이트
+                })
+                .orElseGet(()-> stepRepo.save(s)); // 없으면 신규 생성
+    }
+
+    // 단계 목록 조회 (step_order ASC)
+    public List<MacroStep> listSteps(Long macroId) {
+        return stepRepo.findByMacro_IdOrderByStepOrderAsc(macroId);
+    }
+
+    // 단계 삭제 (특정 매크로의 특정 순서)
+    @Transactional
+    public void deleteStep(Long macroId, Integer order) {
+        stepRepo.deleteByMacro_IdAndStepOrder(macroId,order);
+    }
+
+
+}

--- a/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/service/QrTokenService.java
+++ b/hyo-banking-be/src/main/java/org/atmgigi/hyobankingbe/macro/service/QrTokenService.java
@@ -1,0 +1,50 @@
+package org.atmgigi.hyobankingbe.macro.service;
+
+import org.atmgigi.hyobankingbe.macro.entity.MacroQrToken;
+import org.atmgigi.hyobankingbe.macro.repository.MacroQrTokenRepository;
+import org.atmgigi.hyobankingbe.macro.repository.MacroRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class QrTokenService {
+
+    private final MacroQrTokenRepository tokenRepo;
+    private final MacroRepository macroRepo;
+
+
+    public QrTokenService(MacroQrTokenRepository tokenRepo, MacroRepository macroRepo) {
+        this.tokenRepo = tokenRepo;
+        this.macroRepo = macroRepo;
+    }
+
+    // QR 토큰 생성 (UUID 32자리, 만료시각 설정)
+    @Transactional
+    public MacroQrToken create(Long macroId, Duration ttl) {
+        MacroQrToken t = MacroQrToken.builder()
+                .macro(macroRepo.getReferenceById(macroId))                 // // FK: macro_id
+                .token(UUID.randomUUID().toString().replace("-", ""))       // // 32자 토큰
+                .expiresAt(LocalDateTime.now().plus(ttl))                   // // now + ttl
+                .build();
+        return tokenRepo.save(t);
+    }
+
+    // 토큰 무효화 (usedAt=now)
+    @Transactional
+    public void invalidate(String token) {
+        MacroQrToken t = tokenRepo.findByToken(token)
+                .orElseThrow(()-> new IllegalArgumentException("TOKEN_NOT_FOUND"));
+        t.setUsedAt(LocalDateTime.now());
+    }
+
+    // 토큰 단건 조회
+    public Optional<MacroQrToken> find(String token) {
+        return tokenRepo.findByToken(token);
+    }
+
+}


### PR DESCRIPTION
<!--
PR 제목 컨벤션: [type][scope] subject
-->
feat(be): 매크로 API 1차 뼈대 구현 (#1)

# ✨ 요약
- 매크로/스텝/토큰/실행 엔티티 및 CRUD API 뼈대 구현
- 비즈니스 규칙 검증 및 전역 예외 처리 추가

# 🔗 관련 이슈
Close #1

---

## 📦 변경사항(What)
- **Domain/Entity**
  - Macro, MacroStep, MacroQrToken, MacroExecution 엔티티 및 Enum 정의
- **Repository**
  - JPA 기반 Repository 4종 생성
- **Service**
  - MacroService, QrTokenService, ExecutionService 작성 (비즈니스 로직/검증 포함)
- **DTO**
  - MacroDtos, ExecutionDtos 추가 (요청/응답 바인딩)
- **Controller**
  - MacroController, QrTokenController, ExecutionController 추가
- **Exception**
  - GlobalExceptionHandler 추가 (400/404/409 공통 처리)

## 🎯 배경/의도(Why)
- 매크로 기반 다단계 이체 기능의 API 기본 구조 마련
- 추후 FE 연동/테스트를 위한 최소 단위의 API 제공

## 📡 API / 📚 DB 변경

### API
- **신규**
  - `POST /macros` : 매크로 생성
  - `PATCH /macros/{id}` : 매크로 수정
  - `DELETE /macros/{id}` : 매크로 삭제(DRAFT만)
  - `POST /macros/{id}/steps` : 단계 추가
  - `PUT /macros/{id}/steps/{order}` : 단계 업서트
  - `POST /macros/{id}/qr-tokens` : QR 토큰 발급
  - `POST /executions` : 실행 세션 시작
  - `GET /executions/{id}` : 실행 조회

- **에러 포맷 통일**
  ```json
  { "error": "TOKEN_EXPIRED_OR_USED" }
