### PR TITLE
✨ [feat][mobile] 회원가입 UI 컴포넌트 분리 및 레이아웃 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/hyo-banking-mobile/.gitignore
+++ b/hyo-banking-mobile/.gitignore
@@ -28,3 +28,4 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+.DS_Store

--- a/hyo-banking-mobile/package-lock.json
+++ b/hyo-banking-mobile/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.12",
+        "axios": "^1.11.0",
         "pinia": "^3.0.3",
         "tailwindcss": "^4.1.12",
         "vue": "^3.5.18",
@@ -2157,6 +2158,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2240,6 +2258,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2316,6 +2347,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2448,6 +2491,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2455,6 +2507,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2497,6 +2563,51 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -2938,6 +3049,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2952,6 +3099,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2960,6 +3116,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -3005,6 +3198,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3019,6 +3224,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hookable": {
@@ -3583,6 +3827,36 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4000,6 +4274,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/hyo-banking-mobile/package.json
+++ b/hyo-banking-mobile/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.12",
+    "axios": "^1.11.0",
     "pinia": "^3.0.3",
     "tailwindcss": "^4.1.12",
     "vue": "^3.5.18",

--- a/hyo-banking-mobile/src/apis/client.js
+++ b/hyo-banking-mobile/src/apis/client.js
@@ -1,0 +1,69 @@
+import axios from 'axios';
+
+// Axios 인스턴스 생성
+const apiClient = axios.create({
+  baseURL: '/api',
+  timeout: 10000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// 요청 인터셉터
+apiClient.interceptors.request.use(
+  config => {
+    // 요청 전 로깅 (개발 환경에서만)
+    if (import.meta.env.DEV) {
+      console.log('🚀 API Request:', config.method?.toUpperCase(), config.url, config.data);
+    }
+    return config;
+  },
+  error => {
+    console.error('❌ Request Error:', error);
+    return Promise.reject(error);
+  }
+);
+
+// 응답 인터셉터
+apiClient.interceptors.response.use(
+  response => {
+    // 응답 성공 로깅 (개발 환경에서만)
+    if (import.meta.env.DEV) {
+      console.log('✅ API Response:', response.status, response.config.url, response.data);
+    }
+    return response;
+  },
+  error => {
+    // 에러 로깅
+    console.error('❌ API Error:', error.response?.status, error.response?.data || error.message);
+
+    // 에러 응답 처리
+    if (error.response) {
+      // 서버에서 응답을 받았지만 에러 상태
+      const { status, data } = error.response;
+
+      switch (status) {
+        case 400:
+          throw new Error(data?.message || '잘못된 요청입니다.');
+        case 401:
+          throw new Error('인증이 필요합니다.');
+        case 403:
+          throw new Error('접근 권한이 없습니다.');
+        case 404:
+          throw new Error('요청한 리소스를 찾을 수 없습니다.');
+        case 500:
+          throw new Error('서버 오류가 발생했습니다.');
+        default:
+          throw new Error(data?.message || '알 수 없는 오류가 발생했습니다.');
+      }
+    } else if (error.request) {
+      // 요청은 보냈지만 응답을 받지 못함
+      throw new Error('네트워크 오류가 발생했습니다. 연결을 확인해주세요.');
+    } else {
+      // 요청 설정 중 오류
+      throw new Error('요청 처리 중 오류가 발생했습니다.');
+    }
+  }
+);
+
+export default apiClient;

--- a/hyo-banking-mobile/src/apis/index.js
+++ b/hyo-banking-mobile/src/apis/index.js
@@ -1,0 +1,4 @@
+// API 함수들을 한 곳에서 export
+export * from './user.js';
+export * from './message.js';
+export { default as apiClient } from './client.js';

--- a/hyo-banking-mobile/src/apis/message.js
+++ b/hyo-banking-mobile/src/apis/message.js
@@ -1,0 +1,37 @@
+import apiClient from './client.js';
+
+// 메시지 관련 API 함수들
+
+/**
+ * 인증번호 전송
+ * @param {string} phone - 전화번호
+ * @returns {Promise<string>} 전송 결과 메시지
+ */
+export const sendVerificationCode = async phone => {
+  try {
+    const response = await apiClient.post('/user/message/send', null, {
+      params: { phone },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('인증번호 전송 실패:', error);
+    throw error;
+  }
+};
+
+/**
+ * 인증번호 검증
+ * @param {Object} verificationData - 인증 데이터
+ * @param {string} verificationData.phone - 전화번호
+ * @param {string} verificationData.code - 인증번호
+ * @returns {Promise<string>} 검증 결과 메시지
+ */
+export const verifyCode = async verificationData => {
+  try {
+    const response = await apiClient.post('/user/message/verification', verificationData);
+    return response.data;
+  } catch (error) {
+    console.error('인증번호 검증 실패:', error);
+    throw error;
+  }
+};

--- a/hyo-banking-mobile/src/apis/user.js
+++ b/hyo-banking-mobile/src/apis/user.js
@@ -1,0 +1,72 @@
+import apiClient from './client.js';
+
+// 사용자 관련 API 함수들
+
+/**
+ * 아이디 중복 체크
+ * @param {string} loginId - 확인할 아이디
+ * @returns {Promise<boolean>} 중복 여부 (true: 중복, false: 사용 가능)
+ */
+export const checkDuplicateId = async loginId => {
+  try {
+    const response = await apiClient.get(`/user/duplicationcheck`, {
+      params: { loginId },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('아이디 중복 체크 실패:', error);
+    throw error;
+  }
+};
+
+/**
+ * 회원가입
+ * @param {Object} joinData - 회원가입 데이터
+ * @param {string} joinData.loginId - 아이디
+ * @param {string} joinData.password - 비밀번호
+ * @param {string} joinData.name - 이름
+ * @param {string} joinData.phone - 전화번호
+ * @returns {Promise<Object>} 회원가입 결과
+ */
+export const createUser = async joinData => {
+  try {
+    const response = await apiClient.post('/user/create', joinData);
+    return response.data;
+  } catch (error) {
+    console.error('회원가입 실패:', error);
+    throw error;
+  }
+};
+
+/**
+ * 로그인
+ * @param {Object} loginData - 로그인 데이터
+ * @param {string} loginData.loginId - 아이디
+ * @param {string} loginData.password - 비밀번호
+ * @returns {Promise<Object>} 로그인 결과
+ */
+export const loginUser = async loginData => {
+  try {
+    const response = await apiClient.post('/user/login', loginData);
+    return response.data;
+  } catch (error) {
+    console.error('로그인 실패:', error);
+    throw error;
+  }
+};
+
+/**
+ * 계좌번호로 사용자 조회
+ * @param {string} accountNo - 계좌번호
+ * @param {string} bankCode - 은행 코드
+ * @returns {Promise<Object>} 사용자 정보
+ */
+export const getUserByAccount = async (accountNo, bankCode) => {
+  try {
+    const response = await apiClient.get(`/user/${accountNo}/${bankCode}`);
+    return response.data;
+  } catch (error) {
+    console.error('사용자 조회 실패:', error);
+    throw error;
+  }
+};

--- a/hyo-banking-mobile/src/components/JoinStep1.vue
+++ b/hyo-banking-mobile/src/components/JoinStep1.vue
@@ -1,0 +1,386 @@
+<script setup lang="ts">
+  import { ref, reactive, computed, onUnmounted } from 'vue';
+  import TextInput from '@/components/TextInput.vue';
+  import PrimaryBtn from '@/components/buttons/PrimaryBtn.vue';
+  import { sendVerificationCode, verifyCode } from '@/apis';
+
+  const emit = defineEmits(['next', 'update:formData']);
+
+  const props = defineProps({
+    formData: {
+      type: Object,
+      required: true,
+    },
+    isLoading: {
+      type: Boolean,
+      default: false,
+    },
+  });
+
+  // 반응형 데이터
+  const formErrors = reactive({
+    name: '',
+    phone: '',
+  });
+  const message = ref(null);
+
+  // 휴대폰 인증 관련 상태
+  const phoneVerification = reactive({
+    isVerified: false,
+    isSending: false,
+    isVerifying: false,
+    verificationCode: '',
+    timeRemaining: 0,
+    canResend: false,
+    timer: null,
+  });
+
+  // 인증번호 재전송 가능 여부
+  const canResendCode = computed(() => {
+    return phoneVerification.canResend && !phoneVerification.isSending;
+  });
+
+  // 1단계 폼 유효성 검사 (이름, 전화번호)
+  const validateStep1Form = data => {
+    const errors = {};
+
+    // 이름 검증
+    if (!data.name || data.name.trim() === '') {
+      errors.name = '이름을 입력해주세요.';
+    } else if (data.name.length < 2) {
+      errors.name = '이름은 2자 이상 입력해주세요.';
+    } else if (!/^[가-힣a-zA-Z\s]+$/.test(data.name)) {
+      errors.name = '이름은 한글, 영문만 사용 가능합니다.';
+    }
+
+    // 전화번호 검증
+    if (!data.phone || data.phone.trim() === '') {
+      errors.phone = '전화번호를 입력해주세요.';
+    } else if (!/^010-\d{4}-\d{4}$/.test(data.phone)) {
+      errors.phone = '전화번호는 010-0000-0000 형식으로 입력해주세요.';
+    }
+
+    return {
+      isValid: Object.keys(errors).length === 0,
+      errors,
+    };
+  };
+
+  // 전화번호 포맷팅
+  const formatPhoneNumber = value => {
+    // 숫자만 추출
+    const numbers = value.replace(/\D/g, '');
+
+    // 010으로 시작하는 11자리 숫자인지 확인
+    if (numbers.length === 11 && numbers.startsWith('010')) {
+      return numbers.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3');
+    }
+
+    // 10자리인 경우 010 추가
+    if (numbers.length === 10 && numbers.startsWith('010')) {
+      return numbers.replace(/(\d{3})(\d{3})(\d{4})/, '$1-$2-$3');
+    }
+
+    return value;
+  };
+
+  // 전화번호 입력 처리
+  const handlePhoneInput = event => {
+    const formatted = formatPhoneNumber(event.target.value);
+    emit('update:formData', { ...props.formData, phone: formatted });
+  };
+
+  // 1단계 처리 (이름, 전화번호)
+  const handleStep1 = () => {
+    // 폼 에러 초기화
+    Object.keys(formErrors).forEach(key => delete formErrors[key]);
+    message.value = null;
+
+    // 1단계 폼 유효성 검사
+    const validation = validateStep1Form(props.formData);
+    if (!validation.isValid) {
+      Object.assign(formErrors, validation.errors);
+
+      const validationErrors = [];
+      if (validation.errors.name) validationErrors.push('이름: ' + validation.errors.name);
+      if (validation.errors.phone) validationErrors.push('전화번호: ' + validation.errors.phone);
+
+      message.value = {
+        type: 'error',
+        text: validationErrors.join('\n'),
+      };
+      return;
+    }
+
+    // 휴대폰 인증 검증
+    if (!phoneVerification.isVerified) {
+      if (phoneVerification.timeRemaining > 0) {
+        message.value = {
+          type: 'error',
+          text: '휴대폰 인증번호를 입력하고 인증을 완료해주세요.',
+        };
+      } else {
+        message.value = {
+          type: 'error',
+          text: '휴대폰 인증번호를 전송하고 인증을 완료해주세요.',
+        };
+      }
+      return;
+    }
+
+    // 2단계로 이동
+    emit('next');
+  };
+
+  // 휴대폰 인증번호 전송
+  const handleSendVerificationCode = async () => {
+    if (!props.formData.phone || !/^010-\d{4}-\d{4}$/.test(props.formData.phone)) {
+      message.value = {
+        type: 'error',
+        text: '올바른 전화번호를 입력해주세요.',
+      };
+      return;
+    }
+
+    phoneVerification.isSending = true;
+    message.value = null;
+
+    try {
+      await sendVerificationCode(props.formData.phone);
+
+      phoneVerification.timeRemaining = 300; // 5분
+      phoneVerification.canResend = false;
+
+      // 타이머 시작
+      phoneVerification.timer = setInterval(() => {
+        phoneVerification.timeRemaining--;
+        if (phoneVerification.timeRemaining <= 0) {
+          clearInterval(phoneVerification.timer);
+          phoneVerification.canResend = true;
+        }
+      }, 1000);
+
+      message.value = {
+        type: 'success',
+        text: '인증번호가 전송되었습니다.',
+      };
+    } catch (error) {
+      message.value = {
+        type: 'error',
+        text: error.message || '인증번호 전송에 실패했습니다.',
+      };
+    } finally {
+      phoneVerification.isSending = false;
+    }
+  };
+
+  // 인증번호 확인
+  const handleVerifyCode = async () => {
+    if (!phoneVerification.verificationCode || phoneVerification.verificationCode.length !== 6) {
+      message.value = {
+        type: 'error',
+        text: '6자리 인증번호를 입력해주세요.',
+      };
+      return;
+    }
+
+    phoneVerification.isVerifying = true;
+    message.value = null;
+
+    try {
+      await verifyCode({
+        phone: props.formData.phone,
+        code: phoneVerification.verificationCode,
+      });
+
+      phoneVerification.isVerified = true;
+      clearInterval(phoneVerification.timer);
+
+      message.value = {
+        type: 'success',
+        text: '휴대폰 인증이 완료되었습니다.',
+      };
+    } catch (error) {
+      phoneVerification.isVerified = false;
+      message.value = {
+        type: 'error',
+        text: error.message || '인증번호가 올바르지 않습니다.',
+      };
+    } finally {
+      phoneVerification.isVerifying = false;
+    }
+  };
+
+  // 시간 포맷팅 (MM:SS)
+  const formatTime = seconds => {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes.toString().padStart(2, '0')}:${remainingSeconds.toString().padStart(2, '0')}`;
+  };
+
+  // 컴포넌트 언마운트 시 타이머 정리
+  onUnmounted(() => {
+    if (phoneVerification.timer) {
+      clearInterval(phoneVerification.timer);
+    }
+  });
+</script>
+
+<template>
+  <div class="h-full flex flex-col">
+    <div class="flex-1 space-y-6">
+      <!-- 이름 -->
+      <div class="mb-14">
+        <TextInput
+          id="name"
+          :model-value="formData.name"
+          @update:model-value="value => emit('update:formData', { ...formData, name: value })"
+          type="text"
+          name="name"
+          text="이름"
+          placeholder="이름을 입력하세요"
+          :required="true"
+          :readonly="isLoading"
+          :class="formErrors.name ? 'border-red-500' : ''"
+        />
+        <p v-if="formErrors.name" class="text-red-500 text-sm mt-1">
+          {{ formErrors.name }}
+        </p>
+      </div>
+
+      <!-- 전화번호 -->
+      <div>
+        <div class="flex gap-2">
+          <div class="flex-1">
+            <TextInput
+              id="phone"
+              :model-value="formData.phone"
+              type="tel"
+              name="phone"
+              text="전화번호"
+              placeholder="010-0000-0000"
+              :required="true"
+              :readonly="isLoading || phoneVerification.isVerified"
+              :class="[
+                formErrors.phone ? 'border-red-500' : '',
+                phoneVerification.isVerified ? 'border-green-500' : '',
+              ]"
+              @input="handlePhoneInput"
+            />
+          </div>
+          <button
+            v-if="!phoneVerification.isVerified"
+            type="button"
+            @click="handleSendVerificationCode"
+            :disabled="
+              phoneVerification.isSending ||
+              !formData.phone ||
+              !/^010-\d{4}-\d{4}$/.test(formData.phone)
+            "
+            :class="[
+              'px-4 py-2 text-sm font-medium rounded-lg border transition-colors',
+              phoneVerification.isSending ||
+              !formData.phone ||
+              !/^010-\d{4}-\d{4}$/.test(formData.phone)
+                ? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
+                : 'bg-kb-yellow-200 text-kb-brown-200 border-kb-yellow-200 hover:bg-kb-yellow-300',
+            ]"
+          >
+            <span v-if="phoneVerification.isSending">전송중...</span>
+            <span v-else>인증번호 전송</span>
+          </button>
+          <div
+            v-else
+            class="flex items-center px-4 py-2 text-sm font-medium text-green-600 bg-green-100 rounded-lg border border-green-200"
+          >
+            <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fill-rule="evenodd"
+                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            인증완료
+          </div>
+        </div>
+        <p v-if="formErrors.phone" class="text-red-500 text-sm mt-1">
+          {{ formErrors.phone }}
+        </p>
+      </div>
+
+      <!-- 인증번호 입력 -->
+      <div v-if="phoneVerification.timeRemaining > 0 || phoneVerification.isVerified">
+        <div class="flex gap-2">
+          <div class="flex-1">
+            <TextInput
+              id="verificationCode"
+              v-model="phoneVerification.verificationCode"
+              type="text"
+              name="verificationCode"
+              text="인증번호"
+              placeholder="6자리 인증번호"
+              :required="true"
+              :readonly="isLoading || phoneVerification.isVerified"
+              :class="phoneVerification.isVerified ? 'border-green-500' : ''"
+              maxlength="6"
+            />
+          </div>
+          <button
+            v-if="!phoneVerification.isVerified"
+            type="button"
+            @click="handleVerifyCode"
+            :disabled="
+              phoneVerification.isVerifying || phoneVerification.verificationCode.length !== 6
+            "
+            :class="[
+              'px-4 py-2 text-sm font-medium rounded-lg border transition-colors',
+              phoneVerification.isVerifying || phoneVerification.verificationCode.length !== 6
+                ? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
+                : 'bg-kb-yellow-200 text-kb-brown-200 border-kb-yellow-200 hover:bg-kb-yellow-300',
+            ]"
+          >
+            <span v-if="phoneVerification.isVerifying">확인중...</span>
+            <span v-else>인증확인</span>
+          </button>
+        </div>
+
+        <!-- 타이머 및 재전송 -->
+        <div class="flex justify-between items-center mt-2">
+          <div v-if="phoneVerification.timeRemaining > 0" class="text-sm text-kb-gray-100">
+            남은 시간: {{ formatTime(phoneVerification.timeRemaining) }}
+          </div>
+          <button
+            v-if="canResendCode"
+            type="button"
+            @click="handleSendVerificationCode"
+            class="text-sm text-kb-yellow-200 hover:text-kb-yellow-300 underline"
+          >
+            인증번호 재전송
+          </button>
+        </div>
+      </div>
+
+      <!-- 메시지 표시 -->
+      <div
+        v-if="message"
+        :class="[
+          'text-center text-sm p-3 rounded-lg whitespace-pre-line',
+          message.type === 'error' ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700',
+        ]"
+      >
+        {{ message.text }}
+      </div>
+    </div>
+
+    <!-- 다음 단계 버튼 - 화면 하단 고정 -->
+    <div class="pt-4 pb-10">
+      <PrimaryBtn
+        text="다음 단계"
+        :disabled="isLoading"
+        :isLoading="isLoading"
+        @click="handleStep1"
+        class="w-full py-3"
+      />
+    </div>
+  </div>
+</template>

--- a/hyo-banking-mobile/src/components/JoinStep2.vue
+++ b/hyo-banking-mobile/src/components/JoinStep2.vue
@@ -1,0 +1,295 @@
+<script setup lang="ts">
+  import { ref, reactive } from 'vue';
+  import TextInput from '@/components/TextInput.vue';
+  import PrimaryBtn from '@/components/buttons/PrimaryBtn.vue';
+  import { checkDuplicateId } from '@/apis';
+
+  const emit = defineEmits(['join', 'back', 'update:formData']);
+
+  const props = defineProps({
+    formData: {
+      type: Object,
+      required: true,
+    },
+    isLoading: {
+      type: Boolean,
+      default: false,
+    },
+  });
+
+  // 반응형 데이터
+  const formErrors = reactive({
+    loginId: '',
+    password: '',
+    confirmPassword: '',
+  });
+  const message = ref(null);
+
+  // 아이디 중복 체크 관련 상태
+  const idCheck = reactive({
+    isChecking: false,
+    isChecked: false,
+    isAvailable: false,
+  });
+
+  // 2단계 폼 유효성 검사 (아이디, 비밀번호)
+  const validateStep2Form = data => {
+    const errors = {};
+
+    // 아이디 검증
+    if (!data.loginId || data.loginId.trim() === '') {
+      errors.loginId = '아이디를 입력해주세요.';
+    } else if (data.loginId.length < 3) {
+      errors.loginId = '아이디는 3자 이상 입력해주세요.';
+    } else if (!/^[a-zA-Z0-9]+$/.test(data.loginId)) {
+      errors.loginId = '아이디는 영문과 숫자만 사용 가능합니다.';
+    }
+
+    // 비밀번호 검증
+    if (!data.password || data.password.trim() === '') {
+      errors.password = '비밀번호를 입력해주세요.';
+    } else if (data.password.length < 4) {
+      errors.password = '비밀번호는 4자 이상 입력해주세요.';
+    } else if (!/(?=.*[a-zA-Z])(?=.*\d)/.test(data.password)) {
+      errors.password = '비밀번호는 영문과 숫자를 포함해야 합니다.';
+    }
+
+    // 비밀번호 확인 검증
+    if (!data.confirmPassword || data.confirmPassword.trim() === '') {
+      errors.confirmPassword = '비밀번호 확인을 입력해주세요.';
+    } else if (data.password !== data.confirmPassword) {
+      errors.confirmPassword = '비밀번호가 일치하지 않습니다.';
+    }
+
+    return {
+      isValid: Object.keys(errors).length === 0,
+      errors,
+    };
+  };
+
+  // 아이디 중복 체크
+  const handleCheckDuplicateId = async () => {
+    if (!props.formData.loginId || props.formData.loginId.length < 3) {
+      message.value = {
+        type: 'error',
+        text: '아이디를 3자 이상 입력해주세요.',
+      };
+      return;
+    }
+
+    idCheck.isChecking = true;
+    message.value = null;
+
+    try {
+      const response = await checkDuplicateId(props.formData.loginId);
+
+      if (response) {
+        idCheck.isAvailable = false;
+        idCheck.isChecked = true;
+        message.value = {
+          type: 'error',
+          text: '이미 사용 중인 아이디입니다.',
+        };
+      } else {
+        idCheck.isAvailable = true;
+        idCheck.isChecked = true;
+        message.value = {
+          type: 'success',
+          text: '사용 가능한 아이디입니다.',
+        };
+      }
+    } catch (error) {
+      idCheck.isAvailable = false;
+      idCheck.isChecked = false;
+      message.value = {
+        type: 'error',
+        text: error.message || '아이디 중복 체크 중 오류가 발생했습니다.',
+      };
+    } finally {
+      idCheck.isChecking = false;
+    }
+  };
+
+  // 2단계 처리 (아이디, 비밀번호)
+  const handleStep2 = () => {
+    // 폼 에러 초기화
+    Object.keys(formErrors).forEach(key => delete formErrors[key]);
+    message.value = null;
+
+    // 2단계 폼 유효성 검사
+    const validation = validateStep2Form(props.formData);
+    if (!validation.isValid) {
+      Object.assign(formErrors, validation.errors);
+
+      const validationErrors = [];
+      if (validation.errors.loginId) validationErrors.push('아이디: ' + validation.errors.loginId);
+      if (validation.errors.password)
+        validationErrors.push('비밀번호: ' + validation.errors.password);
+      if (validation.errors.confirmPassword)
+        validationErrors.push('비밀번호 확인: ' + validation.errors.confirmPassword);
+
+      message.value = {
+        type: 'error',
+        text: validationErrors.join('\n'),
+      };
+      return;
+    }
+
+    // 아이디 중복 체크 검증
+    if (!idCheck.isChecked) {
+      message.value = {
+        type: 'error',
+        text: '아이디 중복 체크를 완료해주세요.',
+      };
+      return;
+    } else if (!idCheck.isAvailable) {
+      message.value = {
+        type: 'error',
+        text: '이미 사용 중인 아이디입니다. 다른 아이디를 입력해주세요.',
+      };
+      return;
+    }
+
+    // 회원가입 처리
+    emit('join');
+  };
+</script>
+
+<template>
+  <div class="flex flex-col justify-between">
+    <div class="flex-1 space-y-6">
+      <!-- 아이디 -->
+      <div>
+        <div class="flex gap-2">
+          <div class="flex-1">
+            <TextInput
+              id="loginId"
+              :model-value="formData.loginId"
+              @update:model-value="
+                value => emit('update:formData', { ...formData, loginId: value })
+              "
+              type="text"
+              name="loginId"
+              text="아이디"
+              placeholder="아이디를 입력하세요"
+              :required="true"
+              :readonly="isLoading"
+              :class="[
+                formErrors.loginId ? 'border-red-500' : '',
+                idCheck.isChecked && idCheck.isAvailable ? 'border-green-500' : '',
+                idCheck.isChecked && !idCheck.isAvailable ? 'border-red-500' : '',
+              ]"
+              @input="
+                () => {
+                  idCheck.isChecked = false;
+                  idCheck.isAvailable = false;
+                }
+              "
+            />
+          </div>
+          <button
+            v-if="!idCheck.isChecked || !idCheck.isAvailable"
+            type="button"
+            @click="handleCheckDuplicateId"
+            :disabled="
+              idCheck.isChecking ||
+              !formData.loginId ||
+              formData.loginId.length < 3 ||
+              !/^[a-zA-Z0-9]+$/.test(formData.loginId)
+            "
+            :class="[
+              'px-4 py-2 text-sm font-medium rounded-lg border transition-colors',
+              idCheck.isChecking ||
+              !formData.loginId ||
+              formData.loginId.length < 3 ||
+              !/^[a-zA-Z0-9]+$/.test(formData.loginId)
+                ? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
+                : 'bg-kb-yellow-200 text-kb-brown-200 border-kb-yellow-200 hover:bg-kb-yellow-300',
+            ]"
+          >
+            <span v-if="idCheck.isChecking">확인중...</span>
+            <span v-else>중복체크</span>
+          </button>
+          <div
+            v-else
+            class="flex items-center px-4 py-2 text-sm font-medium text-green-600 bg-green-100 rounded-lg border border-green-200"
+          >
+            <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fill-rule="evenodd"
+                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            사용가능
+          </div>
+        </div>
+        <p v-if="formErrors.loginId" class="text-red-500 text-sm mt-1">
+          {{ formErrors.loginId }}
+        </p>
+      </div>
+
+      <!-- 비밀번호 -->
+      <div>
+        <TextInput
+          id="password"
+          :model-value="formData.password"
+          @update:model-value="value => emit('update:formData', { ...formData, password: value })"
+          type="password"
+          name="password"
+          text="비밀번호"
+          placeholder="비밀번호를 입력하세요"
+          :required="true"
+          :readonly="isLoading"
+          :class="formErrors.password ? 'border-red-500' : ''"
+        />
+        <p v-if="formErrors.password" class="text-red-500 text-sm mt-1">
+          {{ formErrors.password }}
+        </p>
+      </div>
+
+      <!-- 비밀번호 확인 -->
+      <div>
+        <TextInput
+          id="confirmPassword"
+          :model-value="formData.confirmPassword"
+          @update:model-value="
+            value => emit('update:formData', { ...formData, confirmPassword: value })
+          "
+          type="password"
+          name="confirmPassword"
+          text="비밀번호 확인"
+          placeholder="비밀번호를 다시 입력하세요"
+          :required="true"
+          :readonly="isLoading"
+          :class="formErrors.confirmPassword ? 'border-red-500' : ''"
+        />
+        <p v-if="formErrors.confirmPassword" class="text-red-500 text-sm mt-1">
+          {{ formErrors.confirmPassword }}
+        </p>
+      </div>
+
+      <!-- 메시지 표시 -->
+      <div
+        v-if="message"
+        :class="[
+          'text-center text-sm p-3 rounded-lg whitespace-pre-line',
+          message.type === 'error' ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700',
+        ]"
+      >
+        {{ message.text }}
+      </div>
+    </div>
+
+    <!-- 버튼들 - 화면 하단 고정 -->
+    <div class="flex gap-3 pt-4 pb-10">
+      <PrimaryBtn
+        text="회원가입"
+        :disabled="isLoading"
+        :isLoading="isLoading"
+        @click="handleStep2"
+        class="flex-1 py-3"
+      />
+    </div>
+  </div>
+</template>

--- a/hyo-banking-mobile/src/components/TextInput.vue
+++ b/hyo-banking-mobile/src/components/TextInput.vue
@@ -56,13 +56,13 @@
       :id="name"
       v-model="inputValue"
       :readonly="readonly"
-      class="block py-2.5 px-0 w-full text-2xl text-gray-900 bg-transparent border-0 border-b-2 border-gray-300 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-kb-yellow-100 focus:outline-none focus:ring-0 focus:border-kb-yellow-200 peer"
+      class="block py-2.5 px-0 w-full text-2xl text-gray-900 bg-transparent border-0 border-b-2 border-gray-300 appearance-none focus:outline-none focus:ring-0 focus:border-kb-yellow-200 peer"
       placeholder=" "
       :required="required"
     />
     <label
       :for="name"
-      class="peer-focus:font-medium absolute text-2xl text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-6 scale-75 top-0 -z-10 origin-[0] peer-focus:start-0 rtl:peer-focus:translate-x-1/4 rtl:peer-focus:left-auto peer-focus:text-kb-yellow-200 peer-focus:dark:text-kb-yellow-100 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-3 peer-focus:scale-75 peer-focus:-translate-y-6"
+      class="peer-focus:font-medium absolute text-2xl text-gray-500 duration-300 transform -translate-y-6 scale-75 top-0 -z-10 origin-[0] peer-focus:start-0 rtl:peer-focus:translate-x-1/4 rtl:peer-focus:left-auto peer-focus:text-kb-yellow-200 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-3 peer-focus:scale-75 peer-focus:-translate-y-6"
       >{{ text }}</label
     >
   </div>

--- a/hyo-banking-mobile/src/components/layouts/DefaultLayout.vue
+++ b/hyo-banking-mobile/src/components/layouts/DefaultLayout.vue
@@ -6,7 +6,7 @@
   const router = useRouter();
 
   const isShowNav = computed(() => {
-    return !['start', 'login'].includes(route.name);
+    return !['start', 'login', 'join'].includes(route.name);
   });
 
   const handleHomeClick = () => {

--- a/hyo-banking-mobile/src/router/index.js
+++ b/hyo-banking-mobile/src/router/index.js
@@ -73,6 +73,12 @@ const router = createRouter({
           component: () => import('../views/LoginView.vue'),
           meta: { requiresAuth: false },
         },
+        {
+          path: 'join',
+          name: 'join',
+          component: () => import('../views/JoinView.vue'),
+          meta: { requiresAuth: false },
+        },
       ],
     },
 
@@ -92,16 +98,18 @@ router.beforeEach((to, from, next) => {
 
   // 인증이 필요한 페이지인지 확인
   if (to.meta.requiresAuth) {
-    if (authStore.isAuthenticated && authStore.checkTokenExpiry()) {
-      // 로그인되어 있고 토큰이 유효한 경우
+    if (authStore.isAuthenticated) {
+      // 로그인되어 있는 경우
       next();
     } else {
-      // 로그인되지 않았거나 토큰이 만료된 경우 StartView로 리다이렉트
+      // 로그인되지 않은 경우 StartView로 리다이렉트
       next('/start');
     }
   } else {
     // 인증이 필요하지 않은 페이지
-    if (to.name === 'login' && authStore.isAuthenticated && authStore.checkTokenExpiry()) {
+    const publicPages = ['start', 'login', 'join'];
+
+    if (publicPages.includes(to.name) && authStore.isAuthenticated) {
       // 이미 로그인되어 있는 경우 홈으로 리다이렉트
       next('/');
     } else {

--- a/hyo-banking-mobile/src/stores/auth.js
+++ b/hyo-banking-mobile/src/stores/auth.js
@@ -1,174 +1,133 @@
 import { ref, computed } from 'vue';
 import { defineStore } from 'pinia';
+import { createUser, loginUser } from '@/apis';
 
 export const useAuthStore = defineStore('auth', () => {
   // 상태
   const isLoggedIn = ref(false);
   const user = ref(null);
-  const accessToken = ref(null);
-  const refreshToken = ref(null);
-  const loginTime = ref(null);
 
   // 계산된 속성
   const isAuthenticated = computed(() => isLoggedIn.value && user.value !== null);
   const userInfo = computed(() => user.value);
-  const token = computed(() => accessToken.value);
+
+  // 사용자 정보 접근을 위한 computed 속성들
+  const currentUser = computed(() => user.value);
+  const userId = computed(() => user.value?.userId);
+  const userName = computed(() => user.value?.name);
+  const userPhone = computed(() => user.value?.phone);
+  const userLoginId = computed(() => user.value?.loginId);
 
   // 액션들
   const login = async credentials => {
     try {
-      // 실제 API 호출을 시뮬레이션
-      const response = await mockLoginAPI(credentials);
+      // 실제 API 호출
+      const response = await loginUser(credentials);
 
-      if (response.success) {
+      if (response) {
         isLoggedIn.value = true;
-        user.value = response.user;
-        accessToken.value = response.accessToken;
-        refreshToken.value = response.refreshToken;
-        loginTime.value = new Date().toISOString();
+
+        // 백엔드 응답 구조에 맞게 사용자 정보 설정
+        user.value = {
+          userId: response.userId,
+          name: response.name,
+          phone: response.phone,
+          loginId: credentials.loginId, // 로그인 시 사용한 아이디 추가
+        };
 
         // 로컬 스토리지에 저장
         localStorage.setItem('auth_user', JSON.stringify(user.value));
-        localStorage.setItem('auth_token', accessToken.value);
-        localStorage.setItem('auth_refresh_token', refreshToken.value);
-        localStorage.setItem('auth_login_time', loginTime.value);
 
         return { success: true, message: '로그인 성공' };
       } else {
-        return { success: false, message: response.message || '로그인 실패' };
+        return { success: false, message: '로그인 실패' };
       }
     } catch (error) {
       console.error('Login error:', error);
-      return { success: false, message: '로그인 중 오류가 발생했습니다.' };
+      return { success: false, message: error.message || '로그인 중 오류가 발생했습니다.' };
     }
   };
 
   const logout = () => {
     isLoggedIn.value = false;
     user.value = null;
-    accessToken.value = null;
-    refreshToken.value = null;
-    loginTime.value = null;
 
     // 로컬 스토리지에서 제거
     localStorage.removeItem('auth_user');
-    localStorage.removeItem('auth_token');
-    localStorage.removeItem('auth_refresh_token');
-    localStorage.removeItem('auth_login_time');
   };
 
-  const refreshAccessToken = async () => {
+  const join = async joinData => {
     try {
-      if (!refreshToken.value) {
-        throw new Error('No refresh token available');
+      // 실제 API 호출
+      const response = await createUser(joinData);
+
+      // 회원가입 성공 시 사용자 정보를 로컬 스토리지에 저장
+      if (response) {
+        const newUser = {
+          userId: response.userId,
+          name: response.name,
+          phone: response.phone,
+          loginId: joinData.loginId,
+        };
+
+        // 로컬 스토리지에 저장
+        localStorage.setItem('auth_user', JSON.stringify(newUser));
       }
 
-      const response = await mockRefreshTokenAPI(refreshToken.value);
-
-      if (response.success) {
-        accessToken.value = response.accessToken;
-        localStorage.setItem('auth_token', accessToken.value);
-        return true;
-      } else {
-        logout();
-        return false;
-      }
+      return { success: true, message: '회원가입이 완료되었습니다.', data: response };
     } catch (error) {
-      console.error('Token refresh error:', error);
-      logout();
-      return false;
+      console.error('Join error:', error);
+      return { success: false, message: error.message || '회원가입 중 오류가 발생했습니다.' };
     }
   };
 
   const initializeAuth = () => {
     // 페이지 새로고침 시 로컬 스토리지에서 인증 정보 복원
     const storedUser = localStorage.getItem('auth_user');
-    const storedToken = localStorage.getItem('auth_token');
-    const storedRefreshToken = localStorage.getItem('auth_refresh_token');
-    const storedLoginTime = localStorage.getItem('auth_login_time');
 
-    if (storedUser && storedToken) {
+    if (storedUser) {
       try {
-        user.value = JSON.parse(storedUser);
-        accessToken.value = storedToken;
-        refreshToken.value = storedRefreshToken;
-        loginTime.value = storedLoginTime;
-        isLoggedIn.value = true;
+        const parsedUser = JSON.parse(storedUser);
+
+        // 사용자 정보 구조 검증
+        if (parsedUser && parsedUser.userId && parsedUser.name) {
+          user.value = parsedUser;
+          isLoggedIn.value = true;
+
+          console.log('✅ 인증 정보 복원 완료:', {
+            userId: parsedUser.userId,
+            name: parsedUser.name,
+            loginId: parsedUser.loginId,
+          });
+        } else {
+          console.warn('⚠️ 저장된 사용자 정보가 올바르지 않습니다.');
+          logout();
+        }
       } catch (error) {
-        console.error('Failed to restore auth state:', error);
+        console.error('❌ 인증 정보 복원 실패:', error);
         logout();
       }
     }
-  };
-
-  const checkTokenExpiry = () => {
-    if (!loginTime.value) return false;
-
-    const loginDate = new Date(loginTime.value);
-    const now = new Date();
-    const hoursSinceLogin = (now - loginDate) / (1000 * 60 * 60);
-
-    // 24시간 후 토큰 만료로 간주
-    return hoursSinceLogin < 24;
-  };
-
-  // 모의 API 함수들 (실제 구현에서는 실제 API 호출로 대체)
-  const mockLoginAPI = async credentials => {
-    // 실제 API 호출 시뮬레이션
-    await new Promise(resolve => setTimeout(resolve, 1000));
-
-    // 테스트용 더미 데이터
-    if (credentials.username === 'test' && credentials.password === '1234') {
-      return {
-        success: true,
-        user: {
-          id: '1',
-          username: 'test',
-          name: '테스트 사용자',
-          email: 'test@example.com',
-          phone: '010-1234-5678',
-          accountNumber: '123-456-789012',
-          bankCode: 'KB',
-          bankName: '국민은행',
-        },
-        accessToken: 'mock_access_token_' + Date.now(),
-        refreshToken: 'mock_refresh_token_' + Date.now(),
-      };
-    } else {
-      return {
-        success: false,
-        message: '아이디 또는 비밀번호가 올바르지 않습니다.',
-      };
-    }
-  };
-
-  const mockRefreshTokenAPI = async refreshToken => {
-    await new Promise(resolve => setTimeout(resolve, 500));
-
-    return {
-      success: true,
-      accessToken: 'refreshed_access_token_' + Date.now(),
-    };
   };
 
   return {
     // 상태
     isLoggedIn,
     user,
-    accessToken,
-    refreshToken,
-    loginTime,
 
     // 계산된 속성
     isAuthenticated,
     userInfo,
-    token,
+    currentUser,
+    userId,
+    userName,
+    userPhone,
+    userLoginId,
 
     // 액션
     login,
+    join,
     logout,
-    refreshAccessToken,
     initializeAuth,
-    checkTokenExpiry,
   };
 });

--- a/hyo-banking-mobile/src/utils/auth.js
+++ b/hyo-banking-mobile/src/utils/auth.js
@@ -20,10 +20,10 @@ export const validateLoginState = authStore => {
 export const validateLoginForm = credentials => {
   const errors = {};
 
-  if (!credentials.username || credentials.username.trim() === '') {
-    errors.username = '아이디를 입력해주세요.';
-  } else if (credentials.username.length < 3) {
-    errors.username = '아이디는 3자 이상 입력해주세요.';
+  if (!credentials.loginId || credentials.loginId.trim() === '') {
+    errors.loginId = '아이디를 입력해주세요.';
+  } else if (credentials.loginId.length < 3) {
+    errors.loginId = '아이디는 3자 이상 입력해주세요.';
   }
 
   if (!credentials.password || credentials.password.trim() === '') {
@@ -40,7 +40,7 @@ export const validateLoginForm = credentials => {
 
 // 로그인 정보 암호화 (간단한 Base64 인코딩)
 export const encodeCredentials = credentials => {
-  const credentialsString = `${credentials.username}:${credentials.password}`;
+  const credentialsString = `${credentials.loginId}:${credentials.password}`;
   return btoa(credentialsString);
 };
 
@@ -48,48 +48,11 @@ export const encodeCredentials = credentials => {
 export const decodeCredentials = encodedCredentials => {
   try {
     const decoded = atob(encodedCredentials);
-    const [username, password] = decoded.split(':');
-    return { username, password };
+    const [loginId, password] = decoded.split(':');
+    return { loginId, password };
   } catch (error) {
     console.error('Failed to decode credentials:', error);
     return null;
-  }
-};
-
-// 토큰 만료 시간 계산
-export const calculateTokenExpiry = (loginTime, expiresIn = 3600) => {
-  const loginDate = new Date(loginTime);
-  const expiryDate = new Date(loginDate.getTime() + expiresIn * 1000);
-  return expiryDate;
-};
-
-// 토큰 만료까지 남은 시간 (분)
-export const getTokenTimeRemaining = (loginTime, expiresIn = 3600) => {
-  const expiryDate = calculateTokenExpiry(loginTime, expiresIn);
-  const now = new Date();
-  const timeRemaining = expiryDate.getTime() - now.getTime();
-
-  if (timeRemaining <= 0) {
-    return 0;
-  }
-
-  return Math.floor(timeRemaining / (1000 * 60)); // 분 단위로 반환
-};
-
-// 로그인 세션 유지 시간 포맷팅
-export const formatSessionTime = loginTime => {
-  if (!loginTime) return '알 수 없음';
-
-  const loginDate = new Date(loginTime);
-  const now = new Date();
-  const diffMs = now.getTime() - loginDate.getTime();
-  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-  const diffMinutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
-
-  if (diffHours > 0) {
-    return `${diffHours}시간 ${diffMinutes}분`;
-  } else {
-    return `${diffMinutes}분`;
   }
 };
 
@@ -102,11 +65,12 @@ export const maskSensitiveInfo = (info, type = 'default') => {
       return info.replace(/(\d{3})\d{4}(\d{4})/, '$1-****-$2');
     case 'account':
       return info.replace(/(\d{3})\d{3}(\d{6})/, '$1-***-$2');
-    case 'email':
+    case 'email': {
       const [username, domain] = info.split('@');
       const maskedUsername =
         username.length > 2 ? username.substring(0, 2) + '*'.repeat(username.length - 2) : username;
       return `${maskedUsername}@${domain}`;
+    }
     case 'name':
       if (info.length <= 2) return info;
       return info.substring(0, 1) + '*'.repeat(info.length - 2) + info.substring(info.length - 1);

--- a/hyo-banking-mobile/src/views/JoinView.vue
+++ b/hyo-banking-mobile/src/views/JoinView.vue
@@ -1,0 +1,161 @@
+<script setup>
+  import { ref, reactive } from 'vue';
+  import { useRouter } from 'vue-router';
+  import { useAuthStore } from '@/stores/auth';
+  import BackButton from '@/components/buttons/GoBackBtn.vue';
+  import JoinStep1 from '@/components/JoinStep1.vue';
+  import JoinStep2 from '@/components/JoinStep2.vue';
+  import Modal from '@/components/Modal.vue';
+
+  const router = useRouter();
+  const authStore = useAuthStore();
+
+  // 반응형 데이터
+  const isLoading = ref(false);
+  const currentStep = ref(1); // 1: 이름/전화번호, 2: 아이디/비밀번호
+  const joinData = reactive({
+    loginId: '',
+    password: '',
+    confirmPassword: '',
+    name: '',
+    phone: '',
+  });
+  const joinMessage = ref(null);
+  const showModal = ref(false);
+  const modalConfig = ref({
+    title: '',
+    message: '',
+    showCancel: false,
+  });
+
+  // 2단계 처리 (아이디, 비밀번호)
+  const handleStep2 = async () => {
+    isLoading.value = true;
+    joinMessage.value = null;
+
+    try {
+      // 회원가입 요청
+      const result = await authStore.join(joinData);
+
+      if (result.success) {
+        // 회원가입 성공 시 자동 로그인
+        const loginResult = await authStore.login({
+          loginId: joinData.loginId,
+          password: joinData.password,
+        });
+
+        if (loginResult.success) {
+          showAlert('회원가입 완료', '회원가입 및 로그인이 완료되었습니다!');
+        } else {
+          showAlert(
+            '회원가입 완료',
+            '회원가입은 완료되었지만 로그인에 실패했습니다. 다시 로그인해주세요.'
+          );
+        }
+      } else {
+        joinMessage.value = {
+          type: 'error',
+          text: result.message,
+        };
+      }
+    } catch (error) {
+      console.error('Join error:', error);
+      joinMessage.value = {
+        type: 'error',
+        text: '회원가입 중 오류가 발생했습니다.',
+      };
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  // 다음 단계로 이동
+  const handleNext = () => {
+    currentStep.value = 2;
+  };
+
+  // 이전 단계로 이동
+  const handleBack = () => {
+    currentStep.value = 1;
+    joinMessage.value = null;
+  };
+
+  // 폼 데이터 업데이트
+  const updateFormData = newData => {
+    Object.assign(joinData, newData);
+  };
+
+  // 모달 표시
+  const showAlert = (title, message, showCancel = false) => {
+    modalConfig.value = { title, message, showCancel };
+    showModal.value = true;
+  };
+
+  // 모달 확인
+  const handleModalConfirm = () => {
+    showModal.value = false;
+    router.push('/');
+  };
+
+  // 모달 취소
+  const handleModalCancel = () => {
+    showModal.value = false;
+  };
+</script>
+
+<template>
+  <main class="w-full h-full flex flex-col justify-between">
+    <div class="px-5 h-full flex flex-col">
+      <div class="pt-10 pb-8">
+        <BackButton :handle-go-back="currentStep == 2 ? handleBack : null" />
+      </div>
+
+      <h1 class="text-2xl font-bold mb-10">
+        {{ currentStep === 1 ? '회원가입 (1/2)' : '회원가입 (2/2)' }}
+      </h1>
+
+      <!-- 1단계: 이름, 전화번호 -->
+      <JoinStep1
+        v-if="currentStep === 1"
+        :form-data="joinData"
+        :is-loading="isLoading"
+        @next="handleNext"
+        @update:form-data="updateFormData"
+        class="flex-1"
+      />
+
+      <!-- 2단계: 아이디, 비밀번호 -->
+      <JoinStep2
+        v-if="currentStep === 2"
+        :form-data="joinData"
+        :is-loading="isLoading"
+        @join="handleStep2"
+        @back="handleBack"
+        @update:form-data="updateFormData"
+        class="flex-1"
+      />
+    </div>
+
+    <!-- 메시지 표시 -->
+    <div v-if="joinMessage" class="px-5">
+      <div
+        :class="[
+          'text-center text-sm p-3 rounded-lg whitespace-pre-line',
+          joinMessage.type === 'error' ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700',
+        ]"
+      >
+        {{ joinMessage.text }}
+      </div>
+    </div>
+
+    <!-- Modal -->
+    <Modal
+      :isVisible="showModal"
+      :title="modalConfig.title"
+      :message="modalConfig.message"
+      :showCancel="modalConfig.showCancel"
+      @confirm="handleModalConfirm"
+      @cancel="handleModalCancel"
+    />
+  </main>
+</template>

--- a/hyo-banking-mobile/src/views/LoginView.vue
+++ b/hyo-banking-mobile/src/views/LoginView.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { ref, computed, reactive } from 'vue';
+  import { ref, reactive } from 'vue';
   import { useRouter } from 'vue-router';
   import { useAuthStore } from '@/stores/auth';
   import { validateLoginForm, createLoginAttemptManager } from '@/utils/auth';
@@ -13,7 +13,7 @@
   // 반응형 데이터
   const isLoading = ref(false);
   const credentials = reactive({
-    username: '',
+    loginId: '',
     password: '',
     rememberMe: false,
   });
@@ -21,31 +21,43 @@
   const loginMessage = ref(null);
 
   // 계산된 속성
-  const isFormValid = computed(() => {
-    const validation = validateLoginForm(credentials);
-    return validation.isValid;
-  });
 
   const lockoutTimeRemaining = ref(0);
 
   // 메서드
   const handleLogin = async () => {
-    // 폼 유효성 검사
-    const validation = validateLoginForm(credentials);
-    if (!validation.isValid) {
-      Object.assign(formErrors, validation.errors);
-      return;
-    }
-
-    // 로그인 시도 제한 확인
-    if (loginAttemptManager.isLockedOut()) {
-      lockoutTimeRemaining.value = loginAttemptManager.getLockoutTimeRemaining();
-      return;
-    }
-
     // 폼 에러 초기화
     Object.keys(formErrors).forEach(key => delete formErrors[key]);
     loginMessage.value = null;
+
+    // 단계별 검증
+    const validationErrors = [];
+
+    // 1. 로그인 시도 제한 확인
+    if (loginAttemptManager.isLockedOut()) {
+      lockoutTimeRemaining.value = loginAttemptManager.getLockoutTimeRemaining();
+      validationErrors.push('로그인 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.');
+    }
+
+    // 2. 폼 유효성 검사
+    const validation = validateLoginForm(credentials);
+    if (!validation.isValid) {
+      Object.assign(formErrors, validation.errors);
+
+      // 구체적인 필드별 에러 메시지 추가
+      if (validation.errors.loginId) validationErrors.push('아이디: ' + validation.errors.loginId);
+      if (validation.errors.password)
+        validationErrors.push('비밀번호: ' + validation.errors.password);
+    }
+
+    // 검증 실패 시 에러 메시지 표시
+    if (validationErrors.length > 0) {
+      loginMessage.value = {
+        type: 'error',
+        text: validationErrors.join('\n'),
+      };
+      return;
+    }
 
     isLoading.value = true;
 
@@ -79,7 +91,7 @@
       console.error('Login error:', error);
       loginMessage.value = {
         type: 'error',
-        text: '로그인 중 오류가 발생했습니다.',
+        text: error.message || '로그인 중 오류가 발생했습니다.',
       };
     } finally {
       isLoading.value = false;
@@ -122,18 +134,18 @@
       <form @submit.prevent="handleLogin" class="space-y-6">
         <div class="mb-10">
           <TextInput
-            id="username"
-            v-model="credentials.username"
+            id="loginId"
+            v-model="credentials.loginId"
             type="text"
-            name="username"
+            name="loginId"
             text="아이디"
             placeholder="아이디를 입력하세요"
             :required="true"
             :readonly="isLoading"
-            :class="formErrors.username ? 'border-red-500' : ''"
+            :class="formErrors.loginId ? 'border-red-500' : ''"
           />
-          <p v-if="formErrors.username" class="text-red-500 text-sm mt-1">
-            {{ formErrors.username }}
+          <p v-if="formErrors.loginId" class="text-red-500 text-sm mt-1">
+            {{ formErrors.loginId }}
           </p>
         </div>
 
@@ -163,7 +175,7 @@
         <div
           v-if="loginMessage"
           :class="[
-            'text-center text-sm p-3 rounded-lg',
+            'text-center text-sm p-3 rounded-lg whitespace-pre-line',
             loginMessage.type === 'error'
               ? 'bg-red-100 text-red-700'
               : 'bg-green-100 text-green-700',
@@ -185,7 +197,7 @@
     <div class="px-5 pb-10 w-full">
       <PrimaryBtn
         text="로그인"
-        :disabled="isLoading || !isFormValid"
+        :disabled="isLoading"
         :isLoading="isLoading"
         @click="handleLogin"
         class="w-full py-3"

--- a/hyo-banking-mobile/src/views/StartView.vue
+++ b/hyo-banking-mobile/src/views/StartView.vue
@@ -15,6 +15,12 @@
     });
   };
 
+  const handleSignInClick = () => {
+    router.push({
+      name: 'join',
+    });
+  };
+
   const play = async () => {
     authStore.initializeAuth();
 
@@ -72,8 +78,9 @@
         <p class="text-gray-600">더 쉬운 은행 서비스를 이용해보세요</p>
         <img src="" alt="국민은행" />
       </div>
-      <div class="px-5 pb-10 w-full">
+      <div class="px-5 pb-10 w-full flex flex-col gap-5">
         <PrimaryBtn @click="handleStartClick" text="시작하기" class="w-full py-3" />
+        <PrimaryBtn @click="handleSignInClick" text="회원가입" class="w-full py-3" />
       </div>
     </div>
   </main>

--- a/hyo-banking-mobile/vite.config.js
+++ b/hyo-banking-mobile/vite.config.js
@@ -13,4 +13,13 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 });


### PR DESCRIPTION

<!--
PR 제목 컨벤션(권장): [type][scope] subject (#issue)
ex) feat(fe): 로그인 캐시 도입 (#123)

type: feat | fix | refactor | perf | test | docs | chore | build | ci | style | revert
scope: fe | be | infra | data | docs
-->

# ✨ 요약
<!-- 1~2줄로 핵심만: 무엇을 왜 바꾸었는지 -->

- 회원가입 인터페이스를 백엔드 API와 연동

# 🔗 관련 이슈
<!-- Close 키워드를 사용하면 머지 시 자동으로 이슈가 닫힙니다. -->

Close #19

---

## 📦 변경사항(What)

- JoinView를 JoinStep1, JoinStep2 컴포넌트로 분리
- Transaction 뷰 패턴에 맞춰 UI 일관성 확보
- BackButton, Modal 등 공통 컴포넌트 활용
- 버튼을 화면 하단에 고정하여 사용성 개선
- API 클라이언트 구조 개선 (axios 기반)
- JWT 토큰 시스템 제거, 간단한 인증 시스템으로 변경
- 회원가입 성공 시 자동 로그인 기능 구현
- 라우터 가드 개선 (로그인된 사용자의 공개 페이지 접근 제한)

## 🎯 배경/의도(Why)
- 로그인시 휴대폰 인증

## 🖼️ 스크린샷 / 동영상 (UI 변경 시)

https://github.com/user-attachments/assets/b5218dbb-87c9-4e16-964f-b8257785201d

---

## 👀 리뷰어 가이드
- 집중 부탁드리는 포인트: (로직/성능/보안/설계)
- 큰 파일/생성 코드: (리뷰 스킵 가이드가 있으면 명시)

리뷰어: @rla-hyun @hessepark @Ahranah @ckdwlsrh 
작업자: @doongeon @rla-hyun 

