### PR TITLE
✨ [feat][fe] mobile 매크로 CRUD api 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/hyo-banking-mobile/.gitignore
+++ b/hyo-banking-mobile/.gitignore
@@ -28,3 +28,4 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+.DS_Store

--- a/hyo-banking-mobile/package-lock.json
+++ b/hyo-banking-mobile/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.12",
+        "axios": "^1.11.0",
         "pinia": "^3.0.3",
         "tailwindcss": "^4.1.12",
         "vue": "^3.5.18",
@@ -2157,6 +2158,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2240,6 +2258,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2316,6 +2347,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2448,6 +2491,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2455,6 +2507,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2497,6 +2563,51 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -2938,6 +3049,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2952,6 +3099,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2960,6 +3116,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -3005,6 +3198,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3019,6 +3224,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hookable": {
@@ -3583,6 +3827,36 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4000,6 +4274,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/hyo-banking-mobile/package-lock.json
+++ b/hyo-banking-mobile/package-lock.json
@@ -11,9 +11,11 @@
         "@tailwindcss/vite": "^4.1.12",
         "axios": "^1.11.0",
         "pinia": "^3.0.3",
+        "qrcode": "^1.5.4",
         "tailwindcss": "^4.1.12",
         "vue": "^3.5.18",
-        "vue-router": "^4.5.1"
+        "vue-router": "^4.5.1",
+        "vue3-qr-reader": "^1.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.31.0",
@@ -2125,11 +2127,19 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2281,6 +2291,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001737",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
@@ -2328,11 +2347,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2345,7 +2374,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -2441,6 +2469,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2509,6 +2546,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2529,6 +2572,12 @@
       "integrity": "sha512-ozZyibehoe7tOhNaf16lKmljVf+3npZcJIEbJRVftVsmAg5TeA1mGS9dVCZzOwr2xT7xK15V0p7+GZqSPgkuPg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
@@ -3118,6 +3167,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3344,6 +3402,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3525,6 +3592,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -4080,6 +4153,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4110,7 +4192,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4176,6 +4257,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -4291,6 +4381,38 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4372,6 +4494,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4439,6 +4567,32 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-final-newline": {
@@ -4942,6 +5096,15 @@
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
     },
+    "node_modules/vue3-qr-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vue3-qr-reader/-/vue3-qr-reader-1.0.0.tgz",
+      "integrity": "sha512-BRgmR+lDPkNwgL6skSaEOGFg4Aup/FLYnOGFCV0knYHxfbAnliJN/+wr//iqD2G3EOBrXw4TPGNfj/5Wxl7wwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jsqr": "^1.4.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4958,6 +5121,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4966,6 +5135,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wsl-utils": {
@@ -4994,12 +5177,105 @@
         "node": ">=12"
       }
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/hyo-banking-mobile/package.json
+++ b/hyo-banking-mobile/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.12",
+    "axios": "^1.11.0",
     "pinia": "^3.0.3",
     "tailwindcss": "^4.1.12",
     "vue": "^3.5.18",

--- a/hyo-banking-mobile/package.json
+++ b/hyo-banking-mobile/package.json
@@ -17,9 +17,11 @@
     "@tailwindcss/vite": "^4.1.12",
     "axios": "^1.11.0",
     "pinia": "^3.0.3",
+    "qrcode": "^1.5.4",
     "tailwindcss": "^4.1.12",
     "vue": "^3.5.18",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "vue3-qr-reader": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",

--- a/hyo-banking-mobile/src/apis/client.js
+++ b/hyo-banking-mobile/src/apis/client.js
@@ -1,0 +1,69 @@
+import axios from 'axios';
+
+// Axios 인스턴스 생성
+const apiClient = axios.create({
+  baseURL: '/api',
+  timeout: 10000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// 요청 인터셉터
+apiClient.interceptors.request.use(
+  config => {
+    // 요청 전 로깅 (개발 환경에서만)
+    if (import.meta.env.DEV) {
+      console.log('🚀 API Request:', config.method?.toUpperCase(), config.url, config.data);
+    }
+    return config;
+  },
+  error => {
+    console.error('❌ Request Error:', error);
+    return Promise.reject(error);
+  }
+);
+
+// 응답 인터셉터
+apiClient.interceptors.response.use(
+  response => {
+    // 응답 성공 로깅 (개발 환경에서만)
+    if (import.meta.env.DEV) {
+      console.log('✅ API Response:', response.status, response.config.url, response.data);
+    }
+    return response;
+  },
+  error => {
+    // 에러 로깅
+    console.error('❌ API Error:', error.response?.status, error.response?.data || error.message);
+
+    // 에러 응답 처리
+    if (error.response) {
+      // 서버에서 응답을 받았지만 에러 상태
+      const { status, data } = error.response;
+
+      switch (status) {
+        case 400:
+          throw new Error(data?.message || '잘못된 요청입니다.');
+        case 401:
+          throw new Error('인증이 필요합니다.');
+        case 403:
+          throw new Error('접근 권한이 없습니다.');
+        case 404:
+          throw new Error('요청한 리소스를 찾을 수 없습니다.');
+        case 500:
+          throw new Error('서버 오류가 발생했습니다.');
+        default:
+          throw new Error(data?.message || '알 수 없는 오류가 발생했습니다.');
+      }
+    } else if (error.request) {
+      // 요청은 보냈지만 응답을 받지 못함
+      throw new Error('네트워크 오류가 발생했습니다. 연결을 확인해주세요.');
+    } else {
+      // 요청 설정 중 오류
+      throw new Error('요청 처리 중 오류가 발생했습니다.');
+    }
+  }
+);
+
+export default apiClient;

--- a/hyo-banking-mobile/src/apis/index.js
+++ b/hyo-banking-mobile/src/apis/index.js
@@ -1,0 +1,4 @@
+// API 함수들을 한 곳에서 export
+export * from './user.js';
+export * from './message.js';
+export { default as apiClient } from './client.js';

--- a/hyo-banking-mobile/src/apis/index.js
+++ b/hyo-banking-mobile/src/apis/index.js
@@ -1,4 +1,5 @@
 // API 함수들을 한 곳에서 export
 export * from './user.js';
 export * from './message.js';
+export * from './macro.js';
 export { default as apiClient } from './client.js';

--- a/hyo-banking-mobile/src/apis/macro.js
+++ b/hyo-banking-mobile/src/apis/macro.js
@@ -1,0 +1,114 @@
+import apiClient from './client.js';
+
+// 매크로 관련 API 함수들
+
+// 매크로 생성
+export const createMacro = async (userId, name) => {
+  const response = await apiClient.post('/macros', {
+    userId,
+    name,
+  });
+  return response.data;
+};
+
+// 매크로 조회
+export const getMacro = async macroId => {
+  const response = await apiClient.get(`/macros/${macroId}`);
+  return response.data;
+};
+
+// 매크로 목록 조회
+export const getMacros = async (userId, status = null, page = 0, size = 20) => {
+  const params = { userId, page, size };
+  if (status) params.status = status;
+
+  const response = await apiClient.get('/macros', { params });
+  return response.data;
+};
+
+// 매크로 수정
+export const updateMacro = async (macroId, name, status) => {
+  const response = await apiClient.patch(`/macros/${macroId}`, {
+    name,
+    status,
+  });
+  return response.data;
+};
+
+// 매크로 삭제
+export const deleteMacro = async macroId => {
+  await apiClient.delete(`/macros/${macroId}`);
+};
+
+// 매크로 단계 추가
+export const addMacroStep = async (macroId, stepData) => {
+  const response = await apiClient.post(`/macros/${macroId}/steps`, stepData);
+  return response.data;
+};
+
+// 매크로 단계 수정/생성 (upsert)
+export const upsertMacroStep = async (macroId, order, stepData) => {
+  const response = await apiClient.put(`/macros/${macroId}/steps/${order}`, stepData);
+  return response.data;
+};
+
+// 매크로 단계 목록 조회
+export const getMacroSteps = async macroId => {
+  const response = await apiClient.get(`/macros/${macroId}/steps`);
+  return response.data;
+};
+
+// 매크로 단계 삭제
+export const deleteMacroStep = async (macroId, order) => {
+  await apiClient.delete(`/macros/${macroId}/steps/${order}`);
+};
+
+// QR 토큰 생성
+export const createQrToken = async macroId => {
+  const response = await apiClient.post(`/macros/${macroId}/qr-tokens`);
+  return response.data;
+};
+
+// QR 토큰 조회
+export const getQrToken = async token => {
+  const response = await apiClient.get(`/qr-tokens/${token}`);
+  return response.data;
+};
+
+// QR 토큰 무효화
+export const invalidateQrToken = async token => {
+  await apiClient.post(`/qr-tokens/${token}/invalidate`);
+};
+
+// 매크로 실행 시작
+export const startMacroExecution = async (macroId, qrToken) => {
+  const response = await apiClient.post('/executions', {
+    macroId,
+    qrToken,
+  });
+  return response.data;
+};
+
+// 매크로 실행 조회
+export const getMacroExecution = async executionId => {
+  const response = await apiClient.get(`/executions/${executionId}`);
+  return response.data;
+};
+
+// 매크로 실행 목록 조회
+export const getMacroExecutions = async (
+  macroId,
+  status = null,
+  from = null,
+  to = null,
+  page = 0,
+  size = 20
+) => {
+  const params = { macroId, page, size };
+  if (status) params.status = status;
+  if (from) params.from = from;
+  if (to) params.to = to;
+
+  const response = await apiClient.get('/executions', { params });
+  return response.data;
+};

--- a/hyo-banking-mobile/src/apis/message.js
+++ b/hyo-banking-mobile/src/apis/message.js
@@ -1,0 +1,37 @@
+import apiClient from './client.js';
+
+// 메시지 관련 API 함수들
+
+/**
+ * 인증번호 전송
+ * @param {string} phone - 전화번호
+ * @returns {Promise<string>} 전송 결과 메시지
+ */
+export const sendVerificationCode = async phone => {
+  try {
+    const response = await apiClient.post('/user/message/send', null, {
+      params: { phone },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('인증번호 전송 실패:', error);
+    throw error;
+  }
+};
+
+/**
+ * 인증번호 검증
+ * @param {Object} verificationData - 인증 데이터
+ * @param {string} verificationData.phone - 전화번호
+ * @param {string} verificationData.code - 인증번호
+ * @returns {Promise<string>} 검증 결과 메시지
+ */
+export const verifyCode = async verificationData => {
+  try {
+    const response = await apiClient.post('/user/message/verification', verificationData);
+    return response.data;
+  } catch (error) {
+    console.error('인증번호 검증 실패:', error);
+    throw error;
+  }
+};

--- a/hyo-banking-mobile/src/apis/user.js
+++ b/hyo-banking-mobile/src/apis/user.js
@@ -1,0 +1,72 @@
+import apiClient from './client.js';
+
+// 사용자 관련 API 함수들
+
+/**
+ * 아이디 중복 체크
+ * @param {string} loginId - 확인할 아이디
+ * @returns {Promise<boolean>} 중복 여부 (true: 중복, false: 사용 가능)
+ */
+export const checkDuplicateId = async loginId => {
+  try {
+    const response = await apiClient.get(`/user/duplicationcheck`, {
+      params: { loginId },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('아이디 중복 체크 실패:', error);
+    throw error;
+  }
+};
+
+/**
+ * 회원가입
+ * @param {Object} joinData - 회원가입 데이터
+ * @param {string} joinData.loginId - 아이디
+ * @param {string} joinData.password - 비밀번호
+ * @param {string} joinData.name - 이름
+ * @param {string} joinData.phone - 전화번호
+ * @returns {Promise<Object>} 회원가입 결과
+ */
+export const createUser = async joinData => {
+  try {
+    const response = await apiClient.post('/user/create', joinData);
+    return response.data;
+  } catch (error) {
+    console.error('회원가입 실패:', error);
+    throw error;
+  }
+};
+
+/**
+ * 로그인
+ * @param {Object} loginData - 로그인 데이터
+ * @param {string} loginData.loginId - 아이디
+ * @param {string} loginData.password - 비밀번호
+ * @returns {Promise<Object>} 로그인 결과
+ */
+export const loginUser = async loginData => {
+  try {
+    const response = await apiClient.post('/user/login', loginData);
+    return response.data;
+  } catch (error) {
+    console.error('로그인 실패:', error);
+    throw error;
+  }
+};
+
+/**
+ * 계좌번호로 사용자 조회
+ * @param {string} accountNo - 계좌번호
+ * @param {string} bankCode - 은행 코드
+ * @returns {Promise<Object>} 사용자 정보
+ */
+export const getUserByAccount = async (accountNo, bankCode) => {
+  try {
+    const response = await apiClient.get(`/user/${accountNo}/${bankCode}`);
+    return response.data;
+  } catch (error) {
+    console.error('사용자 조회 실패:', error);
+    throw error;
+  }
+};

--- a/hyo-banking-mobile/src/components/JoinStep1.vue
+++ b/hyo-banking-mobile/src/components/JoinStep1.vue
@@ -1,0 +1,386 @@
+<script setup lang="ts">
+  import { ref, reactive, computed, onUnmounted } from 'vue';
+  import TextInput from '@/components/TextInput.vue';
+  import PrimaryBtn from '@/components/buttons/PrimaryBtn.vue';
+  import { sendVerificationCode, verifyCode } from '@/apis';
+
+  const emit = defineEmits(['next', 'update:formData']);
+
+  const props = defineProps({
+    formData: {
+      type: Object,
+      required: true,
+    },
+    isLoading: {
+      type: Boolean,
+      default: false,
+    },
+  });
+
+  // 반응형 데이터
+  const formErrors = reactive({
+    name: '',
+    phone: '',
+  });
+  const message = ref(null);
+
+  // 휴대폰 인증 관련 상태
+  const phoneVerification = reactive({
+    isVerified: false,
+    isSending: false,
+    isVerifying: false,
+    verificationCode: '',
+    timeRemaining: 0,
+    canResend: false,
+    timer: null,
+  });
+
+  // 인증번호 재전송 가능 여부
+  const canResendCode = computed(() => {
+    return phoneVerification.canResend && !phoneVerification.isSending;
+  });
+
+  // 1단계 폼 유효성 검사 (이름, 전화번호)
+  const validateStep1Form = data => {
+    const errors = {};
+
+    // 이름 검증
+    if (!data.name || data.name.trim() === '') {
+      errors.name = '이름을 입력해주세요.';
+    } else if (data.name.length < 2) {
+      errors.name = '이름은 2자 이상 입력해주세요.';
+    } else if (!/^[가-힣a-zA-Z\s]+$/.test(data.name)) {
+      errors.name = '이름은 한글, 영문만 사용 가능합니다.';
+    }
+
+    // 전화번호 검증
+    if (!data.phone || data.phone.trim() === '') {
+      errors.phone = '전화번호를 입력해주세요.';
+    } else if (!/^010-\d{4}-\d{4}$/.test(data.phone)) {
+      errors.phone = '전화번호는 010-0000-0000 형식으로 입력해주세요.';
+    }
+
+    return {
+      isValid: Object.keys(errors).length === 0,
+      errors,
+    };
+  };
+
+  // 전화번호 포맷팅
+  const formatPhoneNumber = value => {
+    // 숫자만 추출
+    const numbers = value.replace(/\D/g, '');
+
+    // 010으로 시작하는 11자리 숫자인지 확인
+    if (numbers.length === 11 && numbers.startsWith('010')) {
+      return numbers.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3');
+    }
+
+    // 10자리인 경우 010 추가
+    if (numbers.length === 10 && numbers.startsWith('010')) {
+      return numbers.replace(/(\d{3})(\d{3})(\d{4})/, '$1-$2-$3');
+    }
+
+    return value;
+  };
+
+  // 전화번호 입력 처리
+  const handlePhoneInput = event => {
+    const formatted = formatPhoneNumber(event.target.value);
+    emit('update:formData', { ...props.formData, phone: formatted });
+  };
+
+  // 1단계 처리 (이름, 전화번호)
+  const handleStep1 = () => {
+    // 폼 에러 초기화
+    Object.keys(formErrors).forEach(key => delete formErrors[key]);
+    message.value = null;
+
+    // 1단계 폼 유효성 검사
+    const validation = validateStep1Form(props.formData);
+    if (!validation.isValid) {
+      Object.assign(formErrors, validation.errors);
+
+      const validationErrors = [];
+      if (validation.errors.name) validationErrors.push('이름: ' + validation.errors.name);
+      if (validation.errors.phone) validationErrors.push('전화번호: ' + validation.errors.phone);
+
+      message.value = {
+        type: 'error',
+        text: validationErrors.join('\n'),
+      };
+      return;
+    }
+
+    // 휴대폰 인증 검증
+    if (!phoneVerification.isVerified) {
+      if (phoneVerification.timeRemaining > 0) {
+        message.value = {
+          type: 'error',
+          text: '휴대폰 인증번호를 입력하고 인증을 완료해주세요.',
+        };
+      } else {
+        message.value = {
+          type: 'error',
+          text: '휴대폰 인증번호를 전송하고 인증을 완료해주세요.',
+        };
+      }
+      return;
+    }
+
+    // 2단계로 이동
+    emit('next');
+  };
+
+  // 휴대폰 인증번호 전송
+  const handleSendVerificationCode = async () => {
+    if (!props.formData.phone || !/^010-\d{4}-\d{4}$/.test(props.formData.phone)) {
+      message.value = {
+        type: 'error',
+        text: '올바른 전화번호를 입력해주세요.',
+      };
+      return;
+    }
+
+    phoneVerification.isSending = true;
+    message.value = null;
+
+    try {
+      await sendVerificationCode(props.formData.phone);
+
+      phoneVerification.timeRemaining = 300; // 5분
+      phoneVerification.canResend = false;
+
+      // 타이머 시작
+      phoneVerification.timer = setInterval(() => {
+        phoneVerification.timeRemaining--;
+        if (phoneVerification.timeRemaining <= 0) {
+          clearInterval(phoneVerification.timer);
+          phoneVerification.canResend = true;
+        }
+      }, 1000);
+
+      message.value = {
+        type: 'success',
+        text: '인증번호가 전송되었습니다.',
+      };
+    } catch (error) {
+      message.value = {
+        type: 'error',
+        text: error.message || '인증번호 전송에 실패했습니다.',
+      };
+    } finally {
+      phoneVerification.isSending = false;
+    }
+  };
+
+  // 인증번호 확인
+  const handleVerifyCode = async () => {
+    if (!phoneVerification.verificationCode || phoneVerification.verificationCode.length !== 6) {
+      message.value = {
+        type: 'error',
+        text: '6자리 인증번호를 입력해주세요.',
+      };
+      return;
+    }
+
+    phoneVerification.isVerifying = true;
+    message.value = null;
+
+    try {
+      await verifyCode({
+        phone: props.formData.phone,
+        code: phoneVerification.verificationCode,
+      });
+
+      phoneVerification.isVerified = true;
+      clearInterval(phoneVerification.timer);
+
+      message.value = {
+        type: 'success',
+        text: '휴대폰 인증이 완료되었습니다.',
+      };
+    } catch (error) {
+      phoneVerification.isVerified = false;
+      message.value = {
+        type: 'error',
+        text: error.message || '인증번호가 올바르지 않습니다.',
+      };
+    } finally {
+      phoneVerification.isVerifying = false;
+    }
+  };
+
+  // 시간 포맷팅 (MM:SS)
+  const formatTime = seconds => {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes.toString().padStart(2, '0')}:${remainingSeconds.toString().padStart(2, '0')}`;
+  };
+
+  // 컴포넌트 언마운트 시 타이머 정리
+  onUnmounted(() => {
+    if (phoneVerification.timer) {
+      clearInterval(phoneVerification.timer);
+    }
+  });
+</script>
+
+<template>
+  <div class="h-full flex flex-col">
+    <div class="flex-1 space-y-6">
+      <!-- 이름 -->
+      <div class="mb-14">
+        <TextInput
+          id="name"
+          :model-value="formData.name"
+          @update:model-value="value => emit('update:formData', { ...formData, name: value })"
+          type="text"
+          name="name"
+          text="이름"
+          placeholder="이름을 입력하세요"
+          :required="true"
+          :readonly="isLoading"
+          :class="formErrors.name ? 'border-red-500' : ''"
+        />
+        <p v-if="formErrors.name" class="text-red-500 text-sm mt-1">
+          {{ formErrors.name }}
+        </p>
+      </div>
+
+      <!-- 전화번호 -->
+      <div>
+        <div class="flex gap-2">
+          <div class="flex-1">
+            <TextInput
+              id="phone"
+              :model-value="formData.phone"
+              type="tel"
+              name="phone"
+              text="전화번호"
+              placeholder="010-0000-0000"
+              :required="true"
+              :readonly="isLoading || phoneVerification.isVerified"
+              :class="[
+                formErrors.phone ? 'border-red-500' : '',
+                phoneVerification.isVerified ? 'border-green-500' : '',
+              ]"
+              @input="handlePhoneInput"
+            />
+          </div>
+          <button
+            v-if="!phoneVerification.isVerified"
+            type="button"
+            @click="handleSendVerificationCode"
+            :disabled="
+              phoneVerification.isSending ||
+              !formData.phone ||
+              !/^010-\d{4}-\d{4}$/.test(formData.phone)
+            "
+            :class="[
+              'px-4 py-2 text-sm font-medium rounded-lg border transition-colors',
+              phoneVerification.isSending ||
+              !formData.phone ||
+              !/^010-\d{4}-\d{4}$/.test(formData.phone)
+                ? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
+                : 'bg-kb-yellow-200 text-kb-brown-200 border-kb-yellow-200 hover:bg-kb-yellow-300',
+            ]"
+          >
+            <span v-if="phoneVerification.isSending">전송중...</span>
+            <span v-else>인증번호 전송</span>
+          </button>
+          <div
+            v-else
+            class="flex items-center px-4 py-2 text-sm font-medium text-green-600 bg-green-100 rounded-lg border border-green-200"
+          >
+            <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fill-rule="evenodd"
+                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            인증완료
+          </div>
+        </div>
+        <p v-if="formErrors.phone" class="text-red-500 text-sm mt-1">
+          {{ formErrors.phone }}
+        </p>
+      </div>
+
+      <!-- 인증번호 입력 -->
+      <div v-if="phoneVerification.timeRemaining > 0 || phoneVerification.isVerified">
+        <div class="flex gap-2">
+          <div class="flex-1">
+            <TextInput
+              id="verificationCode"
+              v-model="phoneVerification.verificationCode"
+              type="text"
+              name="verificationCode"
+              text="인증번호"
+              placeholder="6자리 인증번호"
+              :required="true"
+              :readonly="isLoading || phoneVerification.isVerified"
+              :class="phoneVerification.isVerified ? 'border-green-500' : ''"
+              maxlength="6"
+            />
+          </div>
+          <button
+            v-if="!phoneVerification.isVerified"
+            type="button"
+            @click="handleVerifyCode"
+            :disabled="
+              phoneVerification.isVerifying || phoneVerification.verificationCode.length !== 6
+            "
+            :class="[
+              'px-4 py-2 text-sm font-medium rounded-lg border transition-colors',
+              phoneVerification.isVerifying || phoneVerification.verificationCode.length !== 6
+                ? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
+                : 'bg-kb-yellow-200 text-kb-brown-200 border-kb-yellow-200 hover:bg-kb-yellow-300',
+            ]"
+          >
+            <span v-if="phoneVerification.isVerifying">확인중...</span>
+            <span v-else>인증확인</span>
+          </button>
+        </div>
+
+        <!-- 타이머 및 재전송 -->
+        <div class="flex justify-between items-center mt-2">
+          <div v-if="phoneVerification.timeRemaining > 0" class="text-sm text-kb-gray-100">
+            남은 시간: {{ formatTime(phoneVerification.timeRemaining) }}
+          </div>
+          <button
+            v-if="canResendCode"
+            type="button"
+            @click="handleSendVerificationCode"
+            class="text-sm text-kb-yellow-200 hover:text-kb-yellow-300 underline"
+          >
+            인증번호 재전송
+          </button>
+        </div>
+      </div>
+
+      <!-- 메시지 표시 -->
+      <div
+        v-if="message"
+        :class="[
+          'text-center text-sm p-3 rounded-lg whitespace-pre-line',
+          message.type === 'error' ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700',
+        ]"
+      >
+        {{ message.text }}
+      </div>
+    </div>
+
+    <!-- 다음 단계 버튼 - 화면 하단 고정 -->
+    <div class="pt-4 pb-10">
+      <PrimaryBtn
+        text="다음 단계"
+        :disabled="isLoading"
+        :isLoading="isLoading"
+        @click="handleStep1"
+        class="w-full py-3"
+      />
+    </div>
+  </div>
+</template>

--- a/hyo-banking-mobile/src/components/JoinStep2.vue
+++ b/hyo-banking-mobile/src/components/JoinStep2.vue
@@ -1,0 +1,295 @@
+<script setup lang="ts">
+  import { ref, reactive } from 'vue';
+  import TextInput from '@/components/TextInput.vue';
+  import PrimaryBtn from '@/components/buttons/PrimaryBtn.vue';
+  import { checkDuplicateId } from '@/apis';
+
+  const emit = defineEmits(['join', 'back', 'update:formData']);
+
+  const props = defineProps({
+    formData: {
+      type: Object,
+      required: true,
+    },
+    isLoading: {
+      type: Boolean,
+      default: false,
+    },
+  });
+
+  // 반응형 데이터
+  const formErrors = reactive({
+    loginId: '',
+    password: '',
+    confirmPassword: '',
+  });
+  const message = ref(null);
+
+  // 아이디 중복 체크 관련 상태
+  const idCheck = reactive({
+    isChecking: false,
+    isChecked: false,
+    isAvailable: false,
+  });
+
+  // 2단계 폼 유효성 검사 (아이디, 비밀번호)
+  const validateStep2Form = data => {
+    const errors = {};
+
+    // 아이디 검증
+    if (!data.loginId || data.loginId.trim() === '') {
+      errors.loginId = '아이디를 입력해주세요.';
+    } else if (data.loginId.length < 3) {
+      errors.loginId = '아이디는 3자 이상 입력해주세요.';
+    } else if (!/^[a-zA-Z0-9]+$/.test(data.loginId)) {
+      errors.loginId = '아이디는 영문과 숫자만 사용 가능합니다.';
+    }
+
+    // 비밀번호 검증
+    if (!data.password || data.password.trim() === '') {
+      errors.password = '비밀번호를 입력해주세요.';
+    } else if (data.password.length < 4) {
+      errors.password = '비밀번호는 4자 이상 입력해주세요.';
+    } else if (!/(?=.*[a-zA-Z])(?=.*\d)/.test(data.password)) {
+      errors.password = '비밀번호는 영문과 숫자를 포함해야 합니다.';
+    }
+
+    // 비밀번호 확인 검증
+    if (!data.confirmPassword || data.confirmPassword.trim() === '') {
+      errors.confirmPassword = '비밀번호 확인을 입력해주세요.';
+    } else if (data.password !== data.confirmPassword) {
+      errors.confirmPassword = '비밀번호가 일치하지 않습니다.';
+    }
+
+    return {
+      isValid: Object.keys(errors).length === 0,
+      errors,
+    };
+  };
+
+  // 아이디 중복 체크
+  const handleCheckDuplicateId = async () => {
+    if (!props.formData.loginId || props.formData.loginId.length < 3) {
+      message.value = {
+        type: 'error',
+        text: '아이디를 3자 이상 입력해주세요.',
+      };
+      return;
+    }
+
+    idCheck.isChecking = true;
+    message.value = null;
+
+    try {
+      const response = await checkDuplicateId(props.formData.loginId);
+
+      if (response) {
+        idCheck.isAvailable = false;
+        idCheck.isChecked = true;
+        message.value = {
+          type: 'error',
+          text: '이미 사용 중인 아이디입니다.',
+        };
+      } else {
+        idCheck.isAvailable = true;
+        idCheck.isChecked = true;
+        message.value = {
+          type: 'success',
+          text: '사용 가능한 아이디입니다.',
+        };
+      }
+    } catch (error) {
+      idCheck.isAvailable = false;
+      idCheck.isChecked = false;
+      message.value = {
+        type: 'error',
+        text: error.message || '아이디 중복 체크 중 오류가 발생했습니다.',
+      };
+    } finally {
+      idCheck.isChecking = false;
+    }
+  };
+
+  // 2단계 처리 (아이디, 비밀번호)
+  const handleStep2 = () => {
+    // 폼 에러 초기화
+    Object.keys(formErrors).forEach(key => delete formErrors[key]);
+    message.value = null;
+
+    // 2단계 폼 유효성 검사
+    const validation = validateStep2Form(props.formData);
+    if (!validation.isValid) {
+      Object.assign(formErrors, validation.errors);
+
+      const validationErrors = [];
+      if (validation.errors.loginId) validationErrors.push('아이디: ' + validation.errors.loginId);
+      if (validation.errors.password)
+        validationErrors.push('비밀번호: ' + validation.errors.password);
+      if (validation.errors.confirmPassword)
+        validationErrors.push('비밀번호 확인: ' + validation.errors.confirmPassword);
+
+      message.value = {
+        type: 'error',
+        text: validationErrors.join('\n'),
+      };
+      return;
+    }
+
+    // 아이디 중복 체크 검증
+    if (!idCheck.isChecked) {
+      message.value = {
+        type: 'error',
+        text: '아이디 중복 체크를 완료해주세요.',
+      };
+      return;
+    } else if (!idCheck.isAvailable) {
+      message.value = {
+        type: 'error',
+        text: '이미 사용 중인 아이디입니다. 다른 아이디를 입력해주세요.',
+      };
+      return;
+    }
+
+    // 회원가입 처리
+    emit('join');
+  };
+</script>
+
+<template>
+  <div class="flex flex-col justify-between">
+    <div class="flex-1 space-y-6">
+      <!-- 아이디 -->
+      <div>
+        <div class="flex gap-2">
+          <div class="flex-1">
+            <TextInput
+              id="loginId"
+              :model-value="formData.loginId"
+              @update:model-value="
+                value => emit('update:formData', { ...formData, loginId: value })
+              "
+              type="text"
+              name="loginId"
+              text="아이디"
+              placeholder="아이디를 입력하세요"
+              :required="true"
+              :readonly="isLoading"
+              :class="[
+                formErrors.loginId ? 'border-red-500' : '',
+                idCheck.isChecked && idCheck.isAvailable ? 'border-green-500' : '',
+                idCheck.isChecked && !idCheck.isAvailable ? 'border-red-500' : '',
+              ]"
+              @input="
+                () => {
+                  idCheck.isChecked = false;
+                  idCheck.isAvailable = false;
+                }
+              "
+            />
+          </div>
+          <button
+            v-if="!idCheck.isChecked || !idCheck.isAvailable"
+            type="button"
+            @click="handleCheckDuplicateId"
+            :disabled="
+              idCheck.isChecking ||
+              !formData.loginId ||
+              formData.loginId.length < 3 ||
+              !/^[a-zA-Z0-9]+$/.test(formData.loginId)
+            "
+            :class="[
+              'px-4 py-2 text-sm font-medium rounded-lg border transition-colors',
+              idCheck.isChecking ||
+              !formData.loginId ||
+              formData.loginId.length < 3 ||
+              !/^[a-zA-Z0-9]+$/.test(formData.loginId)
+                ? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed'
+                : 'bg-kb-yellow-200 text-kb-brown-200 border-kb-yellow-200 hover:bg-kb-yellow-300',
+            ]"
+          >
+            <span v-if="idCheck.isChecking">확인중...</span>
+            <span v-else>중복체크</span>
+          </button>
+          <div
+            v-else
+            class="flex items-center px-4 py-2 text-sm font-medium text-green-600 bg-green-100 rounded-lg border border-green-200"
+          >
+            <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fill-rule="evenodd"
+                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            사용가능
+          </div>
+        </div>
+        <p v-if="formErrors.loginId" class="text-red-500 text-sm mt-1">
+          {{ formErrors.loginId }}
+        </p>
+      </div>
+
+      <!-- 비밀번호 -->
+      <div>
+        <TextInput
+          id="password"
+          :model-value="formData.password"
+          @update:model-value="value => emit('update:formData', { ...formData, password: value })"
+          type="password"
+          name="password"
+          text="비밀번호"
+          placeholder="비밀번호를 입력하세요"
+          :required="true"
+          :readonly="isLoading"
+          :class="formErrors.password ? 'border-red-500' : ''"
+        />
+        <p v-if="formErrors.password" class="text-red-500 text-sm mt-1">
+          {{ formErrors.password }}
+        </p>
+      </div>
+
+      <!-- 비밀번호 확인 -->
+      <div>
+        <TextInput
+          id="confirmPassword"
+          :model-value="formData.confirmPassword"
+          @update:model-value="
+            value => emit('update:formData', { ...formData, confirmPassword: value })
+          "
+          type="password"
+          name="confirmPassword"
+          text="비밀번호 확인"
+          placeholder="비밀번호를 다시 입력하세요"
+          :required="true"
+          :readonly="isLoading"
+          :class="formErrors.confirmPassword ? 'border-red-500' : ''"
+        />
+        <p v-if="formErrors.confirmPassword" class="text-red-500 text-sm mt-1">
+          {{ formErrors.confirmPassword }}
+        </p>
+      </div>
+
+      <!-- 메시지 표시 -->
+      <div
+        v-if="message"
+        :class="[
+          'text-center text-sm p-3 rounded-lg whitespace-pre-line',
+          message.type === 'error' ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700',
+        ]"
+      >
+        {{ message.text }}
+      </div>
+    </div>
+
+    <!-- 버튼들 - 화면 하단 고정 -->
+    <div class="flex gap-3 pt-4 pb-10">
+      <PrimaryBtn
+        text="회원가입"
+        :disabled="isLoading"
+        :isLoading="isLoading"
+        @click="handleStep2"
+        class="flex-1 py-3"
+      />
+    </div>
+  </div>
+</template>

--- a/hyo-banking-mobile/src/components/layouts/DefaultLayout.vue
+++ b/hyo-banking-mobile/src/components/layouts/DefaultLayout.vue
@@ -6,7 +6,7 @@
   const router = useRouter();
 
   const isShowNav = computed(() => {
-    return !['start', 'login'].includes(route.name);
+    return !['start', 'login', 'join'].includes(route.name);
   });
 
   const handleHomeClick = () => {

--- a/hyo-banking-mobile/src/constants/index.js
+++ b/hyo-banking-mobile/src/constants/index.js
@@ -4,6 +4,22 @@ export const TASK_TYPES = {
   TRANSFER: 'transfer', // 송금,
 };
 
+// 매크로 단계 타입 (서버와 동일)
+export const MACRO_STEP_TYPES = {
+  BALANCE_CHECK: 'BALANCE_CHECK', // 잔액 조회
+  WITHDRAW: 'WITHDRAW', // 출금
+  DEPOSIT: 'DEPOSIT', // 입금
+  TRANSFER: 'TRANSFER', // 이체
+};
+
+// 통화 코드
+export const CURRENCY_CODES = {
+  KRW: 'KRW', // 한국 원
+  USD: 'USD', // 미국 달러
+  EUR: 'EUR', // 유로
+  JPY: 'JPY', // 일본 엔
+};
+
 export const PAYMENT_TYPES = {
   CARD: 'card',
   BANKBOOK: 'bankbook',

--- a/hyo-banking-mobile/src/router/index.js
+++ b/hyo-banking-mobile/src/router/index.js
@@ -73,6 +73,12 @@ const router = createRouter({
           component: () => import('../views/LoginView.vue'),
           meta: { requiresAuth: false },
         },
+        {
+          path: 'join',
+          name: 'join',
+          component: () => import('../views/JoinView.vue'),
+          meta: { requiresAuth: false },
+        },
       ],
     },
 
@@ -92,16 +98,18 @@ router.beforeEach((to, from, next) => {
 
   // 인증이 필요한 페이지인지 확인
   if (to.meta.requiresAuth) {
-    if (authStore.isAuthenticated && authStore.checkTokenExpiry()) {
-      // 로그인되어 있고 토큰이 유효한 경우
+    if (authStore.isAuthenticated) {
+      // 로그인되어 있는 경우
       next();
     } else {
-      // 로그인되지 않았거나 토큰이 만료된 경우 StartView로 리다이렉트
+      // 로그인되지 않은 경우 StartView로 리다이렉트
       next('/start');
     }
   } else {
     // 인증이 필요하지 않은 페이지
-    if (to.name === 'login' && authStore.isAuthenticated && authStore.checkTokenExpiry()) {
+    const publicPages = ['start', 'login', 'join'];
+
+    if (publicPages.includes(to.name) && authStore.isAuthenticated) {
       // 이미 로그인되어 있는 경우 홈으로 리다이렉트
       next('/');
     } else {

--- a/hyo-banking-mobile/src/router/index.js
+++ b/hyo-banking-mobile/src/router/index.js
@@ -44,6 +44,12 @@ const addTransactionRoutes = [
         component: () => import('../views/transaction/ShowQrView.vue'),
         meta: { requiresAuth: true },
       },
+      {
+        path: 'add-step/:id',
+        name: 'add-step',
+        component: () => import('../views/transaction/AddStepView.vue'),
+        meta: { requiresAuth: true },
+      },
     ],
   },
 ];
@@ -78,6 +84,12 @@ const router = createRouter({
           name: 'join',
           component: () => import('../views/JoinView.vue'),
           meta: { requiresAuth: false },
+        },
+        {
+          path: 'qr-example',
+          name: 'qr-example',
+          component: () => import('../views/QrExampleView.vue'),
+          meta: { requiresAuth: true },
         },
       ],
     },

--- a/hyo-banking-mobile/src/stores/auth.js
+++ b/hyo-banking-mobile/src/stores/auth.js
@@ -1,174 +1,133 @@
 import { ref, computed } from 'vue';
 import { defineStore } from 'pinia';
+import { createUser, loginUser } from '@/apis';
 
 export const useAuthStore = defineStore('auth', () => {
   // 상태
   const isLoggedIn = ref(false);
   const user = ref(null);
-  const accessToken = ref(null);
-  const refreshToken = ref(null);
-  const loginTime = ref(null);
 
   // 계산된 속성
   const isAuthenticated = computed(() => isLoggedIn.value && user.value !== null);
   const userInfo = computed(() => user.value);
-  const token = computed(() => accessToken.value);
+
+  // 사용자 정보 접근을 위한 computed 속성들
+  const currentUser = computed(() => user.value);
+  const userId = computed(() => user.value?.userId);
+  const userName = computed(() => user.value?.name);
+  const userPhone = computed(() => user.value?.phone);
+  const userLoginId = computed(() => user.value?.loginId);
 
   // 액션들
   const login = async credentials => {
     try {
-      // 실제 API 호출을 시뮬레이션
-      const response = await mockLoginAPI(credentials);
+      // 실제 API 호출
+      const response = await loginUser(credentials);
 
-      if (response.success) {
+      if (response) {
         isLoggedIn.value = true;
-        user.value = response.user;
-        accessToken.value = response.accessToken;
-        refreshToken.value = response.refreshToken;
-        loginTime.value = new Date().toISOString();
+
+        // 백엔드 응답 구조에 맞게 사용자 정보 설정
+        user.value = {
+          userId: response.userId,
+          name: response.name,
+          phone: response.phone,
+          loginId: credentials.loginId, // 로그인 시 사용한 아이디 추가
+        };
 
         // 로컬 스토리지에 저장
         localStorage.setItem('auth_user', JSON.stringify(user.value));
-        localStorage.setItem('auth_token', accessToken.value);
-        localStorage.setItem('auth_refresh_token', refreshToken.value);
-        localStorage.setItem('auth_login_time', loginTime.value);
 
         return { success: true, message: '로그인 성공' };
       } else {
-        return { success: false, message: response.message || '로그인 실패' };
+        return { success: false, message: '로그인 실패' };
       }
     } catch (error) {
       console.error('Login error:', error);
-      return { success: false, message: '로그인 중 오류가 발생했습니다.' };
+      return { success: false, message: error.message || '로그인 중 오류가 발생했습니다.' };
     }
   };
 
   const logout = () => {
     isLoggedIn.value = false;
     user.value = null;
-    accessToken.value = null;
-    refreshToken.value = null;
-    loginTime.value = null;
 
     // 로컬 스토리지에서 제거
     localStorage.removeItem('auth_user');
-    localStorage.removeItem('auth_token');
-    localStorage.removeItem('auth_refresh_token');
-    localStorage.removeItem('auth_login_time');
   };
 
-  const refreshAccessToken = async () => {
+  const join = async joinData => {
     try {
-      if (!refreshToken.value) {
-        throw new Error('No refresh token available');
+      // 실제 API 호출
+      const response = await createUser(joinData);
+
+      // 회원가입 성공 시 사용자 정보를 로컬 스토리지에 저장
+      if (response) {
+        const newUser = {
+          userId: response.userId,
+          name: response.name,
+          phone: response.phone,
+          loginId: joinData.loginId,
+        };
+
+        // 로컬 스토리지에 저장
+        localStorage.setItem('auth_user', JSON.stringify(newUser));
       }
 
-      const response = await mockRefreshTokenAPI(refreshToken.value);
-
-      if (response.success) {
-        accessToken.value = response.accessToken;
-        localStorage.setItem('auth_token', accessToken.value);
-        return true;
-      } else {
-        logout();
-        return false;
-      }
+      return { success: true, message: '회원가입이 완료되었습니다.', data: response };
     } catch (error) {
-      console.error('Token refresh error:', error);
-      logout();
-      return false;
+      console.error('Join error:', error);
+      return { success: false, message: error.message || '회원가입 중 오류가 발생했습니다.' };
     }
   };
 
   const initializeAuth = () => {
     // 페이지 새로고침 시 로컬 스토리지에서 인증 정보 복원
     const storedUser = localStorage.getItem('auth_user');
-    const storedToken = localStorage.getItem('auth_token');
-    const storedRefreshToken = localStorage.getItem('auth_refresh_token');
-    const storedLoginTime = localStorage.getItem('auth_login_time');
 
-    if (storedUser && storedToken) {
+    if (storedUser) {
       try {
-        user.value = JSON.parse(storedUser);
-        accessToken.value = storedToken;
-        refreshToken.value = storedRefreshToken;
-        loginTime.value = storedLoginTime;
-        isLoggedIn.value = true;
+        const parsedUser = JSON.parse(storedUser);
+
+        // 사용자 정보 구조 검증
+        if (parsedUser && parsedUser.userId && parsedUser.name) {
+          user.value = parsedUser;
+          isLoggedIn.value = true;
+
+          console.log('✅ 인증 정보 복원 완료:', {
+            userId: parsedUser.userId,
+            name: parsedUser.name,
+            loginId: parsedUser.loginId,
+          });
+        } else {
+          console.warn('⚠️ 저장된 사용자 정보가 올바르지 않습니다.');
+          logout();
+        }
       } catch (error) {
-        console.error('Failed to restore auth state:', error);
+        console.error('❌ 인증 정보 복원 실패:', error);
         logout();
       }
     }
-  };
-
-  const checkTokenExpiry = () => {
-    if (!loginTime.value) return false;
-
-    const loginDate = new Date(loginTime.value);
-    const now = new Date();
-    const hoursSinceLogin = (now - loginDate) / (1000 * 60 * 60);
-
-    // 24시간 후 토큰 만료로 간주
-    return hoursSinceLogin < 24;
-  };
-
-  // 모의 API 함수들 (실제 구현에서는 실제 API 호출로 대체)
-  const mockLoginAPI = async credentials => {
-    // 실제 API 호출 시뮬레이션
-    await new Promise(resolve => setTimeout(resolve, 1000));
-
-    // 테스트용 더미 데이터
-    if (credentials.username === 'test' && credentials.password === '1234') {
-      return {
-        success: true,
-        user: {
-          id: '1',
-          username: 'test',
-          name: '테스트 사용자',
-          email: 'test@example.com',
-          phone: '010-1234-5678',
-          accountNumber: '123-456-789012',
-          bankCode: 'KB',
-          bankName: '국민은행',
-        },
-        accessToken: 'mock_access_token_' + Date.now(),
-        refreshToken: 'mock_refresh_token_' + Date.now(),
-      };
-    } else {
-      return {
-        success: false,
-        message: '아이디 또는 비밀번호가 올바르지 않습니다.',
-      };
-    }
-  };
-
-  const mockRefreshTokenAPI = async refreshToken => {
-    await new Promise(resolve => setTimeout(resolve, 500));
-
-    return {
-      success: true,
-      accessToken: 'refreshed_access_token_' + Date.now(),
-    };
   };
 
   return {
     // 상태
     isLoggedIn,
     user,
-    accessToken,
-    refreshToken,
-    loginTime,
 
     // 계산된 속성
     isAuthenticated,
     userInfo,
-    token,
+    currentUser,
+    userId,
+    userName,
+    userPhone,
+    userLoginId,
 
     // 액션
     login,
+    join,
     logout,
-    refreshAccessToken,
     initializeAuth,
-    checkTokenExpiry,
   };
 });

--- a/hyo-banking-mobile/src/utils/auth.js
+++ b/hyo-banking-mobile/src/utils/auth.js
@@ -20,10 +20,10 @@ export const validateLoginState = authStore => {
 export const validateLoginForm = credentials => {
   const errors = {};
 
-  if (!credentials.username || credentials.username.trim() === '') {
-    errors.username = '아이디를 입력해주세요.';
-  } else if (credentials.username.length < 3) {
-    errors.username = '아이디는 3자 이상 입력해주세요.';
+  if (!credentials.loginId || credentials.loginId.trim() === '') {
+    errors.loginId = '아이디를 입력해주세요.';
+  } else if (credentials.loginId.length < 3) {
+    errors.loginId = '아이디는 3자 이상 입력해주세요.';
   }
 
   if (!credentials.password || credentials.password.trim() === '') {
@@ -40,7 +40,7 @@ export const validateLoginForm = credentials => {
 
 // 로그인 정보 암호화 (간단한 Base64 인코딩)
 export const encodeCredentials = credentials => {
-  const credentialsString = `${credentials.username}:${credentials.password}`;
+  const credentialsString = `${credentials.loginId}:${credentials.password}`;
   return btoa(credentialsString);
 };
 
@@ -48,48 +48,11 @@ export const encodeCredentials = credentials => {
 export const decodeCredentials = encodedCredentials => {
   try {
     const decoded = atob(encodedCredentials);
-    const [username, password] = decoded.split(':');
-    return { username, password };
+    const [loginId, password] = decoded.split(':');
+    return { loginId, password };
   } catch (error) {
     console.error('Failed to decode credentials:', error);
     return null;
-  }
-};
-
-// 토큰 만료 시간 계산
-export const calculateTokenExpiry = (loginTime, expiresIn = 3600) => {
-  const loginDate = new Date(loginTime);
-  const expiryDate = new Date(loginDate.getTime() + expiresIn * 1000);
-  return expiryDate;
-};
-
-// 토큰 만료까지 남은 시간 (분)
-export const getTokenTimeRemaining = (loginTime, expiresIn = 3600) => {
-  const expiryDate = calculateTokenExpiry(loginTime, expiresIn);
-  const now = new Date();
-  const timeRemaining = expiryDate.getTime() - now.getTime();
-
-  if (timeRemaining <= 0) {
-    return 0;
-  }
-
-  return Math.floor(timeRemaining / (1000 * 60)); // 분 단위로 반환
-};
-
-// 로그인 세션 유지 시간 포맷팅
-export const formatSessionTime = loginTime => {
-  if (!loginTime) return '알 수 없음';
-
-  const loginDate = new Date(loginTime);
-  const now = new Date();
-  const diffMs = now.getTime() - loginDate.getTime();
-  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-  const diffMinutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
-
-  if (diffHours > 0) {
-    return `${diffHours}시간 ${diffMinutes}분`;
-  } else {
-    return `${diffMinutes}분`;
   }
 };
 
@@ -102,11 +65,12 @@ export const maskSensitiveInfo = (info, type = 'default') => {
       return info.replace(/(\d{3})\d{4}(\d{4})/, '$1-****-$2');
     case 'account':
       return info.replace(/(\d{3})\d{3}(\d{6})/, '$1-***-$2');
-    case 'email':
+    case 'email': {
       const [username, domain] = info.split('@');
       const maskedUsername =
         username.length > 2 ? username.substring(0, 2) + '*'.repeat(username.length - 2) : username;
       return `${maskedUsername}@${domain}`;
+    }
     case 'name':
       if (info.length <= 2) return info;
       return info.substring(0, 1) + '*'.repeat(info.length - 2) + info.substring(info.length - 1);

--- a/hyo-banking-mobile/src/views/HomeView.vue
+++ b/hyo-banking-mobile/src/views/HomeView.vue
@@ -6,11 +6,13 @@
   import PrimaryBtn from '@/components/buttons/PrimaryBtn.vue';
   import IconBtn from '@/components/buttons/IconBtn.vue';
   import { ref, onMounted } from 'vue';
-  import { STORAGE_KEYS, TASK_TYPES, ICON_URLS } from '@/constants';
+  import { ICON_URLS } from '@/constants';
+  import { getMacros } from '@/apis';
 
   const authStore = useAuthStore();
   const router = useRouter();
-  const recentTransactions = ref([]);
+  const macros = ref([]);
+  const isLoadingMacros = ref(false);
 
   const handleDepositeClick = () => {
     router.push({ name: 'create-deposit' });
@@ -24,47 +26,39 @@
     router.push({ name: 'create-transfer' });
   };
 
-  const handleTransactionClick = transactionId => {
-    router.push({ name: 'transaction-detail', params: { id: transactionId } });
-  };
+  const loadMacros = async () => {
+    if (!authStore.userId) return;
 
-  const loadRecentTransactions = () => {
-    const transactions = JSON.parse(localStorage.getItem(STORAGE_KEYS.TRANSACTIONS) || '[]');
-    recentTransactions.value = transactions.slice(0, 5); // 최근 5개만 표시
-  };
-
-  const getTransactionIcon = type => {
-    switch (type) {
-      case TASK_TYPES.DEPOSIT:
-        return ICON_URLS.MONEY_BOX;
-      case TASK_TYPES.WITHDRAW:
-        return ICON_URLS.MONEY;
-      case TASK_TYPES.TRANSFER:
-        return ICON_URLS.MONEY_TRANSFER;
-      default:
-        return ICON_URLS.MONEY;
+    try {
+      isLoadingMacros.value = true;
+      // DRAFT와 ACTIVE 상태 모두 조회
+      const response = await getMacros(authStore.userId, null, 0, 10);
+      macros.value = response.content || [];
+    } catch (error) {
+      console.error('매크로 로드 오류:', error);
+      macros.value = [];
+    } finally {
+      isLoadingMacros.value = false;
     }
   };
 
-  const getTransactionText = (type, transaction) => {
-    switch (type) {
-      case TASK_TYPES.DEPOSIT:
-        return `계좌에 ${(transaction.amount / 10000).toLocaleString()} 만원 넣기`;
-      case TASK_TYPES.WITHDRAW:
-        return `${(transaction.amount / 10000).toLocaleString()} 만원 뽑기`;
-      case TASK_TYPES.TRANSFER:
-        if (transaction?.recipientName && transaction?.amount) {
-          const amountText = `${(transaction.amount / 10000).toLocaleString()} 만원`;
-          return `${transaction.recipientName}의 계좌에 ${amountText} 보내기`;
-        }
-        return transaction?.recipientName ? `송금 (${transaction.recipientName})` : '송금';
-      default:
-        return '거래';
-    }
+  const handleMacroClick = macro => {
+    // TransactionView로 이동
+    router.push({
+      name: 'transaction-detail',
+      params: {
+        id: macro.id,
+      },
+    });
+  };
+
+  const handleMacroManageClick = () => {
+    // 매크로 관리 페이지로 이동 (추후 구현)
+    router.push({ name: 'macro-list' });
   };
 
   onMounted(() => {
-    loadRecentTransactions();
+    loadMacros();
   });
 
   const menuItems = [
@@ -124,43 +118,71 @@
         </div>
       </div>
 
+      <!-- 저장된 매크로 -->
       <div class="flex flex-col gap-3 bg-white p-6 rounded-2xl shadow-sm mb-6">
-        <h2 class="font-bold text-lg">최근 사용 거래</h2>
+        <div class="flex items-center justify-between">
+          <h2 class="font-bold text-lg">저장된 매크로</h2>
+          <button
+            @click="handleMacroManageClick"
+            class="text-sm text-blue-600 hover:text-blue-800 font-medium"
+          >
+            관리
+          </button>
+        </div>
         <hr class="border-gray-200" />
 
-        <div v-if="recentTransactions.length === 0" class="text-center py-8 text-gray-500">
-          <p>최근 사용한 거래가 없습니다.</p>
+        <div v-if="isLoadingMacros" class="text-center py-8 text-gray-500">
+          <p>매크로를 불러오는 중...</p>
+        </div>
+
+        <div v-else-if="macros.length === 0" class="text-center py-8 text-gray-500">
+          <p>저장된 매크로가 없습니다.</p>
+          <p class="text-sm mt-1">거래 생성 시 매크로로 저장해보세요!</p>
         </div>
 
         <div v-else class="space-y-3">
           <div
-            v-for="transaction in recentTransactions"
-            :key="transaction.id"
-            @click="handleTransactionClick(transaction.id)"
-            class="flex items-center justify-between py-2 cursor-pointer hover:bg-gray-50 rounded-lg p-2 transition-colors"
+            v-for="macro in macros.slice(0, 5)"
+            :key="macro.id"
+            @click="handleMacroClick(macro)"
+            class="flex items-center justify-between py-3 cursor-pointer hover:bg-gray-50 rounded-lg p-3 transition-colors border border-gray-100"
           >
             <div class="flex items-center gap-3">
-              <img
-                :src="getTransactionIcon(transaction.type)"
-                :alt="getTransactionText(transaction.type, transaction)"
-                class="w-8 h-8"
-              />
+              <div class="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center">
+                <span class="text-blue-600 font-bold text-lg">📱</span>
+              </div>
               <div>
-                <p class="font-medium text-gray-900">
-                  {{ getTransactionText(transaction.type, transaction) }}
-                </p>
+                <p class="font-medium text-gray-900">{{ macro.name }}</p>
                 <p class="text-sm text-gray-500">
-                  {{ formatDate(transaction.createdAt) }}
+                  {{ formatDate(macro.createdAt) }}
                 </p>
               </div>
             </div>
-            <img class="size-4" width="30" height="30" :src="ICON_URLS.FORWARD" alt="forward" />
+            <div class="flex items-center gap-2">
+              <span
+                class="text-xs px-2 py-1 rounded-full"
+                :class="{
+                  'bg-green-100 text-green-700': macro.status === 'ACTIVE',
+                  'bg-yellow-100 text-yellow-700': macro.status === 'DRAFT',
+                  'bg-gray-100 text-gray-700': macro.status === 'INACTIVE',
+                }"
+              >
+                {{
+                  macro.status === 'DRAFT'
+                    ? '작성중'
+                    : macro.status === 'ACTIVE'
+                      ? '활성'
+                      : '비활성'
+                }}
+              </span>
+              <img class="size-4" width="30" height="30" :src="ICON_URLS.FORWARD" alt="forward" />
+            </div>
           </div>
         </div>
       </div>
 
       <!-- 메뉴 버튼들 -->
-      <div class="flex flex-col gap-3 bg-white p-6 rounded-2xl shadow-sm">
+      <div class="flex flex-col gap-3 bg-white p-6 rounded-2xl shadow-sm mb-6">
         <h2 class="font-bold text-lg">ATM 거래 추가하기</h2>
         <hr class="border-gray-200" />
         <template v-for="(item, index) in menuItems" :key="item.id">
@@ -172,6 +194,18 @@
           />
           <hr v-if="index < menuItems.length - 1" class="border-gray-200" />
         </template>
+      </div>
+
+      <!-- QR 예제 버튼 -->
+      <div class="bg-white rounded-2xl shadow-sm p-6">
+        <h2 class="font-bold text-lg mb-4">개발자 도구</h2>
+        <button
+          @click="() => router.push({ name: 'qr-example' })"
+          class="w-full py-3 px-4 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors font-medium flex items-center justify-center gap-2"
+        >
+          <span>📱</span>
+          QR 코드 생성/스캔 예제
+        </button>
       </div>
     </div>
   </main>

--- a/hyo-banking-mobile/src/views/JoinView.vue
+++ b/hyo-banking-mobile/src/views/JoinView.vue
@@ -1,0 +1,161 @@
+<script setup>
+  import { ref, reactive } from 'vue';
+  import { useRouter } from 'vue-router';
+  import { useAuthStore } from '@/stores/auth';
+  import BackButton from '@/components/buttons/GoBackBtn.vue';
+  import JoinStep1 from '@/components/JoinStep1.vue';
+  import JoinStep2 from '@/components/JoinStep2.vue';
+  import Modal from '@/components/Modal.vue';
+
+  const router = useRouter();
+  const authStore = useAuthStore();
+
+  // 반응형 데이터
+  const isLoading = ref(false);
+  const currentStep = ref(1); // 1: 이름/전화번호, 2: 아이디/비밀번호
+  const joinData = reactive({
+    loginId: '',
+    password: '',
+    confirmPassword: '',
+    name: '',
+    phone: '',
+  });
+  const joinMessage = ref(null);
+  const showModal = ref(false);
+  const modalConfig = ref({
+    title: '',
+    message: '',
+    showCancel: false,
+  });
+
+  // 2단계 처리 (아이디, 비밀번호)
+  const handleStep2 = async () => {
+    isLoading.value = true;
+    joinMessage.value = null;
+
+    try {
+      // 회원가입 요청
+      const result = await authStore.join(joinData);
+
+      if (result.success) {
+        // 회원가입 성공 시 자동 로그인
+        const loginResult = await authStore.login({
+          loginId: joinData.loginId,
+          password: joinData.password,
+        });
+
+        if (loginResult.success) {
+          showAlert('회원가입 완료', '회원가입 및 로그인이 완료되었습니다!');
+        } else {
+          showAlert(
+            '회원가입 완료',
+            '회원가입은 완료되었지만 로그인에 실패했습니다. 다시 로그인해주세요.'
+          );
+        }
+      } else {
+        joinMessage.value = {
+          type: 'error',
+          text: result.message,
+        };
+      }
+    } catch (error) {
+      console.error('Join error:', error);
+      joinMessage.value = {
+        type: 'error',
+        text: '회원가입 중 오류가 발생했습니다.',
+      };
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  // 다음 단계로 이동
+  const handleNext = () => {
+    currentStep.value = 2;
+  };
+
+  // 이전 단계로 이동
+  const handleBack = () => {
+    currentStep.value = 1;
+    joinMessage.value = null;
+  };
+
+  // 폼 데이터 업데이트
+  const updateFormData = newData => {
+    Object.assign(joinData, newData);
+  };
+
+  // 모달 표시
+  const showAlert = (title, message, showCancel = false) => {
+    modalConfig.value = { title, message, showCancel };
+    showModal.value = true;
+  };
+
+  // 모달 확인
+  const handleModalConfirm = () => {
+    showModal.value = false;
+    router.push('/');
+  };
+
+  // 모달 취소
+  const handleModalCancel = () => {
+    showModal.value = false;
+  };
+</script>
+
+<template>
+  <main class="w-full h-full flex flex-col justify-between">
+    <div class="px-5 h-full flex flex-col">
+      <div class="pt-10 pb-8">
+        <BackButton :handle-go-back="currentStep == 2 ? handleBack : null" />
+      </div>
+
+      <h1 class="text-2xl font-bold mb-10">
+        {{ currentStep === 1 ? '회원가입 (1/2)' : '회원가입 (2/2)' }}
+      </h1>
+
+      <!-- 1단계: 이름, 전화번호 -->
+      <JoinStep1
+        v-if="currentStep === 1"
+        :form-data="joinData"
+        :is-loading="isLoading"
+        @next="handleNext"
+        @update:form-data="updateFormData"
+        class="flex-1"
+      />
+
+      <!-- 2단계: 아이디, 비밀번호 -->
+      <JoinStep2
+        v-if="currentStep === 2"
+        :form-data="joinData"
+        :is-loading="isLoading"
+        @join="handleStep2"
+        @back="handleBack"
+        @update:form-data="updateFormData"
+        class="flex-1"
+      />
+    </div>
+
+    <!-- 메시지 표시 -->
+    <div v-if="joinMessage" class="px-5">
+      <div
+        :class="[
+          'text-center text-sm p-3 rounded-lg whitespace-pre-line',
+          joinMessage.type === 'error' ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700',
+        ]"
+      >
+        {{ joinMessage.text }}
+      </div>
+    </div>
+
+    <!-- Modal -->
+    <Modal
+      :isVisible="showModal"
+      :title="modalConfig.title"
+      :message="modalConfig.message"
+      :showCancel="modalConfig.showCancel"
+      @confirm="handleModalConfirm"
+      @cancel="handleModalCancel"
+    />
+  </main>
+</template>

--- a/hyo-banking-mobile/src/views/LoginView.vue
+++ b/hyo-banking-mobile/src/views/LoginView.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { ref, computed, reactive } from 'vue';
+  import { ref, reactive } from 'vue';
   import { useRouter } from 'vue-router';
   import { useAuthStore } from '@/stores/auth';
   import { validateLoginForm, createLoginAttemptManager } from '@/utils/auth';
@@ -13,7 +13,7 @@
   // 반응형 데이터
   const isLoading = ref(false);
   const credentials = reactive({
-    username: '',
+    loginId: '',
     password: '',
     rememberMe: false,
   });
@@ -21,31 +21,43 @@
   const loginMessage = ref(null);
 
   // 계산된 속성
-  const isFormValid = computed(() => {
-    const validation = validateLoginForm(credentials);
-    return validation.isValid;
-  });
 
   const lockoutTimeRemaining = ref(0);
 
   // 메서드
   const handleLogin = async () => {
-    // 폼 유효성 검사
-    const validation = validateLoginForm(credentials);
-    if (!validation.isValid) {
-      Object.assign(formErrors, validation.errors);
-      return;
-    }
-
-    // 로그인 시도 제한 확인
-    if (loginAttemptManager.isLockedOut()) {
-      lockoutTimeRemaining.value = loginAttemptManager.getLockoutTimeRemaining();
-      return;
-    }
-
     // 폼 에러 초기화
     Object.keys(formErrors).forEach(key => delete formErrors[key]);
     loginMessage.value = null;
+
+    // 단계별 검증
+    const validationErrors = [];
+
+    // 1. 로그인 시도 제한 확인
+    if (loginAttemptManager.isLockedOut()) {
+      lockoutTimeRemaining.value = loginAttemptManager.getLockoutTimeRemaining();
+      validationErrors.push('로그인 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.');
+    }
+
+    // 2. 폼 유효성 검사
+    const validation = validateLoginForm(credentials);
+    if (!validation.isValid) {
+      Object.assign(formErrors, validation.errors);
+
+      // 구체적인 필드별 에러 메시지 추가
+      if (validation.errors.loginId) validationErrors.push('아이디: ' + validation.errors.loginId);
+      if (validation.errors.password)
+        validationErrors.push('비밀번호: ' + validation.errors.password);
+    }
+
+    // 검증 실패 시 에러 메시지 표시
+    if (validationErrors.length > 0) {
+      loginMessage.value = {
+        type: 'error',
+        text: validationErrors.join('\n'),
+      };
+      return;
+    }
 
     isLoading.value = true;
 
@@ -79,7 +91,7 @@
       console.error('Login error:', error);
       loginMessage.value = {
         type: 'error',
-        text: '로그인 중 오류가 발생했습니다.',
+        text: error.message || '로그인 중 오류가 발생했습니다.',
       };
     } finally {
       isLoading.value = false;
@@ -122,18 +134,18 @@
       <form @submit.prevent="handleLogin" class="space-y-6">
         <div class="mb-10">
           <TextInput
-            id="username"
-            v-model="credentials.username"
+            id="loginId"
+            v-model="credentials.loginId"
             type="text"
-            name="username"
+            name="loginId"
             text="아이디"
             placeholder="아이디를 입력하세요"
             :required="true"
             :readonly="isLoading"
-            :class="formErrors.username ? 'border-red-500' : ''"
+            :class="formErrors.loginId ? 'border-red-500' : ''"
           />
-          <p v-if="formErrors.username" class="text-red-500 text-sm mt-1">
-            {{ formErrors.username }}
+          <p v-if="formErrors.loginId" class="text-red-500 text-sm mt-1">
+            {{ formErrors.loginId }}
           </p>
         </div>
 
@@ -163,7 +175,7 @@
         <div
           v-if="loginMessage"
           :class="[
-            'text-center text-sm p-3 rounded-lg',
+            'text-center text-sm p-3 rounded-lg whitespace-pre-line',
             loginMessage.type === 'error'
               ? 'bg-red-100 text-red-700'
               : 'bg-green-100 text-green-700',
@@ -185,7 +197,7 @@
     <div class="px-5 pb-10 w-full">
       <PrimaryBtn
         text="로그인"
-        :disabled="isLoading || !isFormValid"
+        :disabled="isLoading"
         :isLoading="isLoading"
         @click="handleLogin"
         class="w-full py-3"

--- a/hyo-banking-mobile/src/views/QrExampleView.vue
+++ b/hyo-banking-mobile/src/views/QrExampleView.vue
@@ -1,0 +1,428 @@
+<template>
+  <main class="w-full h-full flex flex-col">
+    <div class="px-5 pt-10 pb-6">
+      <BackButton />
+      <h1 class="text-2xl font-bold">QR 코드 예제</h1>
+    </div>
+
+    <div class="px-5 flex-1">
+      <!-- 탭 메뉴 -->
+      <div class="flex bg-gray-100 rounded-lg p-1 mb-6">
+        <button
+          @click="activeTab = 'generate'"
+          :class="[
+            'flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors',
+            activeTab === 'generate'
+              ? 'bg-white text-blue-600 shadow-sm'
+              : 'text-gray-600 hover:text-gray-900',
+          ]"
+        >
+          QR 생성
+        </button>
+        <button
+          @click="activeTab = 'scan'"
+          :class="[
+            'flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors',
+            activeTab === 'scan'
+              ? 'bg-white text-blue-600 shadow-sm'
+              : 'text-gray-600 hover:text-gray-900',
+          ]"
+        >
+          QR 스캔
+        </button>
+      </div>
+
+      <!-- QR 생성 탭 -->
+      <div v-if="activeTab === 'generate'" class="space-y-6">
+        <!-- 입력 섹션 -->
+        <div class="bg-white rounded-2xl shadow-sm p-6">
+          <h2 class="text-lg font-semibold text-gray-700 mb-4">QR 코드 생성</h2>
+
+          <div class="space-y-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-2"> 텍스트 입력 </label>
+              <TextInput
+                v-model="qrText"
+                placeholder="QR 코드로 변환할 텍스트를 입력하세요"
+                @input="generateQR"
+              />
+            </div>
+
+            <div class="grid grid-cols-2 gap-4">
+              <div>
+                <label class="block text-sm font-medium text-gray-700 mb-2"> 크기 (px) </label>
+                <select
+                  v-model="qrSize"
+                  @change="generateQR"
+                  class="w-full p-2 border border-gray-300 rounded-lg"
+                >
+                  <option value="128">128px</option>
+                  <option value="256">256px</option>
+                  <option value="512">512px</option>
+                </select>
+              </div>
+
+              <div>
+                <label class="block text-sm font-medium text-gray-700 mb-2"> 색상 </label>
+                <select
+                  v-model="qrColor"
+                  @change="generateQR"
+                  class="w-full p-2 border border-gray-300 rounded-lg"
+                >
+                  <option value="#000000">검정</option>
+                  <option value="#2563eb">파랑</option>
+                  <option value="#dc2626">빨강</option>
+                  <option value="#059669">초록</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- QR 코드 표시 -->
+        <div v-if="qrCodeUrl" class="bg-white rounded-2xl shadow-sm p-6">
+          <h3 class="text-lg font-semibold text-gray-700 mb-4">생성된 QR 코드</h3>
+          <div class="text-center">
+            <img
+              :src="qrCodeUrl"
+              :alt="qrText"
+              class="mx-auto border-2 border-gray-200 rounded-lg"
+              :style="{ width: qrSize + 'px', height: qrSize + 'px' }"
+            />
+            <p class="mt-4 text-sm text-gray-600 break-all">{{ qrText }}</p>
+          </div>
+
+          <div class="mt-4 flex gap-2">
+            <button
+              @click="downloadQR"
+              class="flex-1 py-2 px-4 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              다운로드
+            </button>
+            <button
+              @click="copyQRText"
+              class="flex-1 py-2 px-4 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors"
+            >
+              텍스트 복사
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- QR 스캔 탭 -->
+      <div v-if="activeTab === 'scan'" class="space-y-6">
+        <!-- 스캔 섹션 -->
+        <div class="bg-white rounded-2xl shadow-sm p-6">
+          <h2 class="text-lg font-semibold text-gray-700 mb-4">QR 코드 스캔</h2>
+
+          <div v-if="!isScanning" class="text-center">
+            <button
+              @click="startScanning"
+              class="w-full py-3 px-4 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors font-medium"
+            >
+              카메라로 QR 스캔 시작
+            </button>
+          </div>
+
+          <div v-else class="space-y-4">
+            <!-- QR 리더 컴포넌트 -->
+            <div class="relative">
+              <QrStream
+                @decode="onDecode"
+                @init="onInit"
+                class="w-full h-64 bg-gray-100 rounded-lg"
+              />
+              <div
+                class="absolute inset-0 border-2 border-green-500 rounded-lg pointer-events-none"
+              >
+                <div
+                  class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-32 h-32 border-2 border-white rounded-lg"
+                ></div>
+              </div>
+            </div>
+
+            <button
+              @click="stopScanning"
+              class="w-full py-2 px-4 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+            >
+              스캔 중지
+            </button>
+          </div>
+        </div>
+
+        <!-- 스캔 결과 -->
+        <div v-if="scannedText" class="bg-white rounded-2xl shadow-sm p-6">
+          <h3 class="text-lg font-semibold text-gray-700 mb-4">스캔 결과</h3>
+          <div class="bg-gray-50 rounded-lg p-4">
+            <p class="text-sm text-gray-600 mb-2">스캔된 텍스트:</p>
+            <p class="break-all text-gray-900 font-mono">{{ scannedText }}</p>
+          </div>
+
+          <div class="mt-4 flex gap-2">
+            <button
+              @click="copyScannedText"
+              class="flex-1 py-2 px-4 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              복사
+            </button>
+            <button
+              @click="clearScannedText"
+              class="flex-1 py-2 px-4 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors"
+            >
+              지우기
+            </button>
+          </div>
+        </div>
+
+        <!-- 스캔 히스토리 -->
+        <div v-if="scanHistory.length > 0" class="bg-white rounded-2xl shadow-sm p-6">
+          <h3 class="text-lg font-semibold text-gray-700 mb-4">스캔 히스토리</h3>
+          <div class="space-y-2 max-h-40 overflow-y-auto">
+            <div
+              v-for="(item, index) in scanHistory"
+              :key="index"
+              class="flex items-center justify-between p-2 bg-gray-50 rounded-lg"
+            >
+              <span class="text-sm text-gray-700 truncate flex-1 mr-2">{{ item }}</span>
+              <button
+                @click="copyHistoryText(item)"
+                class="text-xs px-2 py-1 bg-blue-100 text-blue-600 rounded hover:bg-blue-200 transition-colors"
+              >
+                복사
+              </button>
+            </div>
+          </div>
+          <button
+            @click="clearHistory"
+            class="mt-3 w-full py-2 px-4 bg-red-100 text-red-600 rounded-lg hover:bg-red-200 transition-colors text-sm"
+          >
+            히스토리 지우기
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- 알림 모달 -->
+    <Modal
+      :isVisible="showModal"
+      :title="modalConfig.title"
+      :message="modalConfig.message"
+      :showCancel="modalConfig.showCancel"
+      @confirm="handleModalConfirm"
+      @cancel="handleModalCancel"
+    />
+  </main>
+</template>
+
+<script setup>
+  import { ref, onMounted } from 'vue';
+  import { useRouter } from 'vue-router';
+  import QRCode from 'qrcode';
+  import { QrStream } from 'vue3-qr-reader';
+  import TextInput from '@/components/TextInput.vue';
+  import BackButton from '@/components/buttons/GoBackBtn.vue';
+  import Modal from '@/components/Modal.vue';
+
+  const router = useRouter();
+
+  // 탭 상태
+  const activeTab = ref('generate');
+
+  // QR 생성 관련
+  const qrText = ref('Hello QR Code!');
+  const qrSize = ref(256);
+  const qrColor = ref('#000000');
+  const qrCodeUrl = ref('');
+
+  // QR 스캔 관련
+  const isScanning = ref(false);
+  const scannedText = ref('');
+  const scanHistory = ref([]);
+
+  // 모달 관련
+  const showModal = ref(false);
+  const modalConfig = ref({
+    title: '',
+    message: '',
+    showCancel: false,
+  });
+
+  // QR 코드 생성
+  const generateQR = async () => {
+    if (!qrText.value.trim()) {
+      qrCodeUrl.value = '';
+      return;
+    }
+
+    try {
+      const options = {
+        width: qrSize.value,
+        margin: 2,
+        color: {
+          dark: qrColor.value,
+          light: '#FFFFFF',
+        },
+      };
+
+      qrCodeUrl.value = await QRCode.toDataURL(qrText.value, options);
+    } catch (error) {
+      console.error('QR 코드 생성 오류:', error);
+      showAlert('오류', 'QR 코드 생성 중 오류가 발생했습니다.');
+    }
+  };
+
+  // QR 코드 다운로드
+  const downloadQR = () => {
+    if (!qrCodeUrl.value) return;
+
+    const link = document.createElement('a');
+    link.download = `qrcode-${Date.now()}.png`;
+    link.href = qrCodeUrl.value;
+    link.click();
+  };
+
+  // QR 텍스트 복사
+  const copyQRText = async () => {
+    try {
+      await navigator.clipboard.writeText(qrText.value);
+      showAlert('복사 완료', '텍스트가 클립보드에 복사되었습니다.');
+    } catch (error) {
+      console.error('복사 오류:', error);
+      showAlert('오류', '복사 중 오류가 발생했습니다.');
+    }
+  };
+
+  // 스캔 시작
+  const startScanning = () => {
+    isScanning.value = true;
+    scannedText.value = '';
+  };
+
+  // 스캔 중지
+  const stopScanning = () => {
+    isScanning.value = false;
+  };
+
+  // QR 디코드 성공
+  const onDecode = decodedString => {
+    scannedText.value = decodedString;
+    if (!scanHistory.value.includes(decodedString)) {
+      scanHistory.value.unshift(decodedString);
+      if (scanHistory.value.length > 10) {
+        scanHistory.value = scanHistory.value.slice(0, 10);
+      }
+    }
+    stopScanning();
+  };
+
+  // QR 리더 초기화
+  const onInit = promise => {
+    promise
+      .then(() => {
+        console.log('QR 리더 초기화 성공');
+      })
+      .catch(error => {
+        console.error('QR 리더 초기화 실패:', error);
+        showAlert('오류', '카메라 접근 권한이 필요합니다.');
+        stopScanning();
+      });
+  };
+
+  // 스캔된 텍스트 복사
+  const copyScannedText = async () => {
+    try {
+      await navigator.clipboard.writeText(scannedText.value);
+      showAlert('복사 완료', '스캔된 텍스트가 클립보드에 복사되었습니다.');
+    } catch (error) {
+      console.error('복사 오류:', error);
+      showAlert('오류', '복사 중 오류가 발생했습니다.');
+    }
+  };
+
+  // 히스토리 텍스트 복사
+  const copyHistoryText = async text => {
+    try {
+      await navigator.clipboard.writeText(text);
+      showAlert('복사 완료', '텍스트가 클립보드에 복사되었습니다.');
+    } catch (error) {
+      console.error('복사 오류:', error);
+      showAlert('오류', '복사 중 오류가 발생했습니다.');
+    }
+  };
+
+  // 스캔된 텍스트 지우기
+  const clearScannedText = () => {
+    scannedText.value = '';
+  };
+
+  // 히스토리 지우기
+  const clearHistory = () => {
+    scanHistory.value = [];
+  };
+
+  // 알림 표시
+  const showAlert = (title, message, showCancel = false) => {
+    modalConfig.value = { title, message, showCancel };
+    showModal.value = true;
+  };
+
+  // 모달 확인
+  const handleModalConfirm = () => {
+    showModal.value = false;
+  };
+
+  // 모달 취소
+  const handleModalCancel = () => {
+    showModal.value = false;
+  };
+
+  // 컴포넌트 마운트 시 초기 QR 생성
+  onMounted(() => {
+    generateQR();
+  });
+</script>
+
+<style scoped>
+  /* QR 스캔 영역 스타일링 */
+  .qr-scanner {
+    position: relative;
+    overflow: hidden;
+    border-radius: 0.5rem;
+  }
+
+  /* 스캔 가이드 라인 */
+  .scan-guide {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 200px;
+    height: 200px;
+    border: 2px solid #10b981;
+    border-radius: 0.5rem;
+    pointer-events: none;
+  }
+
+  .scan-guide::before,
+  .scan-guide::after {
+    content: '';
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    border: 3px solid #10b981;
+  }
+
+  .scan-guide::before {
+    top: -3px;
+    left: -3px;
+    border-right: none;
+    border-bottom: none;
+  }
+
+  .scan-guide::after {
+    bottom: -3px;
+    right: -3px;
+    border-left: none;
+    border-top: none;
+  }
+</style>

--- a/hyo-banking-mobile/src/views/StartView.vue
+++ b/hyo-banking-mobile/src/views/StartView.vue
@@ -15,6 +15,12 @@
     });
   };
 
+  const handleSignInClick = () => {
+    router.push({
+      name: 'join',
+    });
+  };
+
   const play = async () => {
     authStore.initializeAuth();
 
@@ -72,8 +78,9 @@
         <p class="text-gray-600">더 쉬운 은행 서비스를 이용해보세요</p>
         <img src="" alt="국민은행" />
       </div>
-      <div class="px-5 pb-10 w-full">
+      <div class="px-5 pb-10 w-full flex flex-col gap-5">
         <PrimaryBtn @click="handleStartClick" text="시작하기" class="w-full py-3" />
+        <PrimaryBtn @click="handleSignInClick" text="회원가입" class="w-full py-3" />
       </div>
     </div>
   </main>

--- a/hyo-banking-mobile/src/views/transaction/AddStepView.vue
+++ b/hyo-banking-mobile/src/views/transaction/AddStepView.vue
@@ -1,0 +1,296 @@
+<script setup>
+  import { ref, onMounted } from 'vue';
+  import { useRouter, useRoute } from 'vue-router';
+  import { formatDate } from '@/utils/formatters';
+  import BackButton from '@/components/buttons/GoBackBtn.vue';
+  import Modal from '@/components/Modal.vue';
+  import { getMacro, getMacroSteps, getMacros, addMacroStep } from '@/apis';
+  import PrimaryBtn from '@/components/buttons/PrimaryBtn.vue';
+
+  const router = useRouter();
+  const route = useRoute();
+
+  const currentMacro = ref(null);
+  const availableMacros = ref([]);
+  const selectedMacro = ref(null);
+  const selectedMacroSteps = ref([]);
+  const isLoading = ref(false);
+  const showModal = ref(false);
+  const modalConfig = ref({
+    title: '',
+    message: '',
+    showCancel: false,
+  });
+
+  onMounted(() => {
+    loadData();
+  });
+
+  const loadData = async () => {
+    const macroId = route.params.id;
+    if (!macroId) {
+      router.push({ name: 'home' });
+      return;
+    }
+
+    try {
+      isLoading.value = true;
+
+      // 현재 매크로 로드
+      currentMacro.value = await getMacro(macroId);
+
+      // 사용자의 다른 매크로들 로드
+      const response = await getMacros(currentMacro.value.userId, null, 0, 100);
+      availableMacros.value = response.content.filter(m => m.id !== macroId);
+    } catch (error) {
+      console.error('데이터 로드 오류:', error);
+      showAlert('오류', '데이터를 불러오는 중 오류가 발생했습니다.');
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  const selectMacro = async macro => {
+    selectedMacro.value = macro;
+
+    try {
+      // 선택된 매크로의 단계들 로드
+      selectedMacroSteps.value = await getMacroSteps(macro.id);
+    } catch (error) {
+      console.error('매크로 단계 로드 오류:', error);
+      selectedMacroSteps.value = [];
+    }
+  };
+
+  const handleAddStep = async () => {
+    if (!selectedMacro.value) return;
+
+    try {
+      // 현재 매크로의 기존 단계 수를 가져와서 순서 설정
+      const currentMacroSteps = await getMacroSteps(currentMacro.value.id);
+      let nextStepOrder = currentMacroSteps.length + 1;
+
+      // 선택된 매크로의 단계들을 현재 매크로에 추가
+      for (const step of selectedMacroSteps.value) {
+        const newStepData = {
+          stepOrder: nextStepOrder,
+          stepType: step.stepType,
+          amount: step.amount,
+          currencyCode: step.currencyCode,
+          sourceAccountNo: step.sourceAccountNo,
+          sourceBankCode: step.sourceBankCode,
+          targetAccountNo: step.targetAccountNo,
+          targetBankCode: step.targetBankCode,
+          note: step.note,
+        };
+        await addMacroStep(currentMacro.value.id, newStepData);
+        nextStepOrder++; // 다음 단계 순서 증가
+      }
+
+      showAlert('작업 추가 완료', `${selectedMacro.value.name}의 작업이 추가되었습니다.`);
+    } catch (error) {
+      console.error('작업 추가 오류:', error);
+      showAlert('오류', '작업 추가 중 오류가 발생했습니다.');
+    }
+  };
+
+  const getStepTypeText = type => {
+    switch (type) {
+      case 'BALANCE_CHECK':
+        return '잔액 조회';
+      case 'WITHDRAW':
+        return '출금';
+      case 'DEPOSIT':
+        return '입금';
+      case 'TRANSFER':
+        return '이체';
+      default:
+        return '거래';
+    }
+  };
+
+  const formatAmount = amount => {
+    if (!amount) return '0원';
+    return `${(amount / 10000).toLocaleString()}만원`;
+  };
+
+  const showAlert = (title, message, showCancel = false) => {
+    modalConfig.value = { title, message, showCancel };
+    showModal.value = true;
+  };
+
+  const handleModalConfirm = () => {
+    showModal.value = false;
+    router.push({
+      name: 'transaction-detail',
+      params: { id: currentMacro.value.id },
+    });
+  };
+
+  const handleModalCancel = () => {
+    showModal.value = false;
+  };
+</script>
+
+<template>
+  <main class="w-full h-full flex flex-col">
+    <div class="px-5 pt-10 pb-6">
+      <div class="mb-6">
+        <BackButton />
+      </div>
+
+      <h1 class="text-2xl font-bold">작업 추가</h1>
+    </div>
+
+    <div v-if="isLoading" class="px-5 flex-1 flex items-center justify-center">
+      <div class="text-center">
+        <div
+          class="animate-spin rounded-full h-16 w-16 border-b-2 border-blue-600 mx-auto mb-4"
+        ></div>
+        <p class="text-gray-500 text-lg">매크로 목록을 불러오는 중...</p>
+      </div>
+    </div>
+
+    <div
+      v-else-if="availableMacros.length === 0"
+      class="px-5 flex-1 flex items-center justify-center"
+    >
+      <div class="text-center">
+        <div class="text-gray-400 text-6xl mb-4">📱</div>
+        <p class="text-gray-500 text-lg mb-2">추가할 수 있는 매크로가 없습니다</p>
+        <p class="text-gray-400 text-sm">다른 매크로를 먼저 생성해주세요</p>
+        <button
+          @click="() => router.push({ name: 'home' })"
+          class="mt-4 px-6 py-2 bg-blue-600 text-white rounded-xl font-semibold"
+        >
+          홈으로 돌아가기
+        </button>
+      </div>
+    </div>
+
+    <div v-else class="px-5 flex-1">
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-700 mb-2">현재 매크로</h2>
+        <div class="bg-blue-50 rounded-lg p-4">
+          <div class="flex items-center gap-3">
+            <div class="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center">
+              <span class="text-blue-600 font-bold text-lg">📱</span>
+            </div>
+            <div>
+              <p class="font-medium text-gray-900">{{ currentMacro.name }}</p>
+              <p class="text-sm text-gray-500">{{ formatDate(currentMacro.createdAt) }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-700 mb-4">추가할 매크로 선택</h2>
+        <div class="space-y-3">
+          <div
+            v-for="availableMacro in availableMacros"
+            :key="availableMacro.id"
+            @click="selectMacro(availableMacro)"
+            class="flex items-center p-4 rounded-lg cursor-pointer transition-colors border-2"
+            :class="{
+              'bg-blue-50 border-blue-300': selectedMacro?.id === availableMacro.id,
+              'bg-white border-gray-200 hover:bg-gray-50': selectedMacro?.id !== availableMacro.id,
+            }"
+          >
+            <div class="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mr-4">
+              <span class="text-green-600 font-bold text-xl">➕</span>
+            </div>
+            <div class="flex-1">
+              <p class="font-medium text-gray-900">{{ availableMacro.name }}</p>
+              <p class="text-sm text-gray-500">{{ formatDate(availableMacro.createdAt) }}</p>
+              <div class="mt-1">
+                <span
+                  class="text-xs px-2 py-1 rounded-full"
+                  :class="{
+                    'bg-green-100 text-green-700': availableMacro.status === 'ACTIVE',
+                    'bg-yellow-100 text-yellow-700': availableMacro.status === 'DRAFT',
+                    'bg-gray-100 text-gray-700': availableMacro.status === 'INACTIVE',
+                  }"
+                >
+                  {{
+                    availableMacro.status === 'DRAFT'
+                      ? '작성중'
+                      : availableMacro.status === 'ACTIVE'
+                        ? '활성'
+                        : '비활성'
+                  }}
+                </span>
+              </div>
+            </div>
+            <div v-if="selectedMacro?.id === availableMacro.id" class="text-blue-600 text-xl">
+              ✓
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="selectedMacro" class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-700 mb-4">선택된 매크로 상세</h3>
+        <div class="bg-gray-50 rounded-lg p-4">
+          <div class="flex items-center gap-3 mb-3">
+            <div class="w-10 h-10 bg-green-100 rounded-full flex items-center justify-center">
+              <span class="text-green-600 font-bold text-lg">📱</span>
+            </div>
+            <div>
+              <p class="font-medium text-gray-900">{{ selectedMacro.name }}</p>
+              <p class="text-sm text-gray-500">{{ formatDate(selectedMacro.createdAt) }}</p>
+            </div>
+          </div>
+
+          <div v-if="selectedMacroSteps.length > 0">
+            <p class="text-sm font-medium text-gray-700 mb-2">포함된 작업:</p>
+            <div class="space-y-2">
+              <div
+                v-for="(step, index) in selectedMacroSteps"
+                :key="step.id"
+                class="flex items-center gap-2 p-2 bg-white rounded border"
+              >
+                <div
+                  class="w-6 h-6 bg-blue-100 rounded-full flex items-center justify-center text-blue-600 font-bold text-xs"
+                >
+                  {{ index + 1 }}
+                </div>
+                <span class="text-sm text-gray-700">{{ getStepTypeText(step.stepType) }}</span>
+                <span v-if="step.amount" class="text-sm text-gray-500">
+                  - {{ formatAmount(step.amount) }}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="availableMacros.length > 0" class="px-5 pb-10">
+      <div class="flex gap-3">
+        <button
+          @click="() => router.back()"
+          class="w-full py-2 bg-gray-200 text-gray-700 rounded-xl font-medium"
+        >
+          취소
+        </button>
+        <PrimaryBtn
+          class="w-full py-2"
+          @click="handleAddStep"
+          :disabled="!selectedMacro"
+          text="작업 추가"
+        />
+      </div>
+    </div>
+
+    <!-- 확인 모달 -->
+    <Modal
+      :isVisible="showModal"
+      :title="modalConfig.title"
+      :message="modalConfig.message"
+      :showCancel="modalConfig.showCancel"
+      @confirm="handleModalConfirm"
+      @cancel="handleModalCancel"
+    />
+  </main>
+</template>

--- a/hyo-banking-mobile/src/views/transaction/CreateDepositView.vue
+++ b/hyo-banking-mobile/src/views/transaction/CreateDepositView.vue
@@ -5,14 +5,18 @@
   import PrimaryBtn from '@/components/buttons/PrimaryBtn.vue';
   import BackButton from '@/components/buttons/GoBackBtn.vue';
   import Modal from '@/components/Modal.vue';
-  import { TASK_TYPES, STORAGE_KEYS } from '@/constants';
   import { useRouter } from 'vue-router';
+  import { useAuthStore } from '@/stores/auth';
+  import { createMacro, addMacroStep } from '@/apis';
 
   const router = useRouter();
+  const authStore = useAuthStore();
   const amount = ref('');
   const showNumberPad = ref(false);
   const showModal = ref(false);
   const showAmountError = ref(false);
+  const macroName = ref('');
+  const showMacroNameInput = ref(false);
   const modalConfig = ref({
     title: '',
     message: '',
@@ -34,6 +38,9 @@
 
   const handleAmountSelect = value => {
     amount.value = value;
+    if (!showMacroNameInput.value) {
+      macroName.value = `${value}만원 입금`;
+    }
   };
 
   const showAlert = (title, message, showCancel = false) => {
@@ -41,42 +48,53 @@
     showModal.value = true;
   };
 
-  const handleAddTransaction = () => {
+  const toggleMacroNameInput = () => {
+    showMacroNameInput.value = !showMacroNameInput.value;
+    if (!showMacroNameInput.value && amount.value) {
+      macroName.value = `${amount.value}만원 입금`;
+    }
+  };
+
+  const handleAddTransaction = async () => {
     if (!amount.value || amount.value === '0') {
       showAmountError.value = true;
-      // 3초 후 에러 메시지 숨기기
       setTimeout(() => {
         showAmountError.value = false;
       }, 3000);
       return;
     }
 
-    // 거래 정보 생성
-    const transaction = {
-      id: Date.now().toString(),
-      type: TASK_TYPES.DEPOSIT,
-      amount: parseInt(amount.value) * 10000, // 만원을 원으로 변환
-      createdAt: new Date().toISOString(),
-    };
+    if (!macroName.value.trim()) {
+      macroName.value = `${amount.value}만원 입금`;
+    }
 
-    // 기존 거래 목록 가져오기
-    const existingTransactions = JSON.parse(
-      localStorage.getItem(STORAGE_KEYS.TRANSACTIONS) || '[]'
-    );
+    try {
+      const macro = await createMacro(authStore.userId, macroName.value.trim());
+      const stepData = {
+        stepOrder: 1,
+        stepType: 'DEPOSIT',
+        amount: parseInt(amount.value) * 10000,
+        currencyCode: 'KRW',
+        sourceAccountNo: null,
+        sourceBankCode: null,
+        targetAccountNo: null,
+        targetBankCode: null,
+        note: `입금 매크로 - ${amount.value}만원`,
+      };
+      await addMacroStep(macro.id, stepData);
 
-    // 새 거래 추가
-    existingTransactions.unshift(transaction);
-
-    // 로컬스토리지에 저장
-    localStorage.setItem(STORAGE_KEYS.TRANSACTIONS, JSON.stringify(existingTransactions));
-
-    showAlert('거래 완료', '입금 거래가 추가되었습니다.');
+      showAlert('매크로 생성 완료', `"${macro.name}" 매크로가 생성되었습니다.`);
+      amount.value = '';
+      macroName.value = '';
+    } catch (error) {
+      console.error('매크로 생성 오류:', error);
+      showAlert('오류', error.message || '매크로 생성 중 오류가 발생했습니다.');
+    }
   };
 
   const handleModalConfirm = () => {
     showModal.value = false;
-    // 홈으로 이동
-    window.history.back();
+    router.push({ name: 'home' });
   };
 
   const handleModalCancel = () => {
@@ -92,6 +110,35 @@
       </div>
 
       <h1 class="text-2xl font-bold mb-10">얼마를 넣으시겠어요?</h1>
+
+      <!-- 매크로 이름 설정 -->
+      <div class="mb-10">
+        <div class="flex items-center justify-between mb-3">
+          <span class="text-sm font-medium text-gray-700">매크로 이름</span>
+          <button
+            @click="toggleMacroNameInput"
+            class="text-sm text-blue-600 hover:text-blue-800 font-medium"
+          >
+            {{ showMacroNameInput ? '기본값 사용' : '직접 설정' }}
+          </button>
+        </div>
+        <div v-if="showMacroNameInput" class="mb-3">
+          <TextInput
+            v-model="macroName"
+            text=""
+            name="macroName"
+            :required="true"
+            type="text"
+            placeholder="예: 월말 입금, 급여 입금"
+          />
+        </div>
+        <div v-else class="bg-gray-50 rounded-lg p-3">
+          <p class="text-sm text-gray-600">
+            {{ macroName || '금액을 선택하면 자동으로 설정됩니다' }}
+          </p>
+        </div>
+      </div>
+
       <div @click="handleAmountClick" class="cursor-pointer flex items-center gap-3 pb-3">
         <TextInput
           class="text-xl"
@@ -127,7 +174,7 @@
         금액을 입력해주세요
       </div>
 
-      <PrimaryBtn class="w-full py-2" text="거래 추가" @click="handleAddTransaction" />
+      <PrimaryBtn class="w-full py-2" text="매크로 생성" @click="handleAddTransaction" />
     </div>
 
     <!-- Number Pad -->

--- a/hyo-banking-mobile/src/views/transaction/CreateWithdrawView.vue
+++ b/hyo-banking-mobile/src/views/transaction/CreateWithdrawView.vue
@@ -5,14 +5,18 @@
   import PrimaryBtn from '@/components/buttons/PrimaryBtn.vue';
   import BackButton from '@/components/buttons/GoBackBtn.vue';
   import Modal from '@/components/Modal.vue';
-  import { TASK_TYPES, STORAGE_KEYS } from '@/constants';
   import { useRouter } from 'vue-router';
+  import { useAuthStore } from '@/stores/auth';
+  import { createMacro, addMacroStep } from '@/apis';
 
   const router = useRouter();
+  const authStore = useAuthStore();
   const amount = ref('');
   const showNumberPad = ref(false);
   const showModal = ref(false);
   const showAmountError = ref(false);
+  const macroName = ref('');
+  const showMacroNameInput = ref(false);
   const modalConfig = ref({
     title: '',
     message: '',
@@ -26,6 +30,10 @@
   const handleNumberPadConfirm = value => {
     amount.value = value;
     showNumberPad.value = false;
+    // 금액이 변경되면 기본 매크로 이름도 업데이트
+    if (!showMacroNameInput.value) {
+      macroName.value = `${value}만원 출금`;
+    }
   };
 
   const handleNumberPadCancel = () => {
@@ -34,6 +42,18 @@
 
   const handleAmountSelect = value => {
     amount.value = value;
+    // 금액이 변경되면 기본 매크로 이름도 업데이트
+    if (!showMacroNameInput.value) {
+      macroName.value = `${value}만원 출금`;
+    }
+  };
+
+  const toggleMacroNameInput = () => {
+    showMacroNameInput.value = !showMacroNameInput.value;
+    if (!showMacroNameInput.value && amount.value) {
+      // 매크로 이름 입력을 숨기면 기본값으로 설정
+      macroName.value = `${amount.value}만원 출금`;
+    }
   };
 
   const showAlert = (title, message, showCancel = false) => {
@@ -41,7 +61,7 @@
     showModal.value = true;
   };
 
-  const handleAddTransaction = () => {
+  const handleAddTransaction = async () => {
     if (!amount.value || amount.value === '0') {
       showAmountError.value = true;
       // 3초 후 에러 메시지 숨기기
@@ -51,26 +71,40 @@
       return;
     }
 
-    // 거래 정보 생성
-    const transaction = {
-      id: Date.now().toString(),
-      type: TASK_TYPES.WITHDRAW,
-      amount: parseInt(amount.value) * 10000, // 만원을 원으로 변환
-      createdAt: new Date().toISOString(),
-    };
+    // 매크로 이름이 비어있으면 기본값으로 설정
+    if (!macroName.value.trim()) {
+      macroName.value = `${amount.value}만원 출금`;
+    }
 
-    // 기존 거래 목록 가져오기
-    const existingTransactions = JSON.parse(
-      localStorage.getItem(STORAGE_KEYS.TRANSACTIONS) || '[]'
-    );
+    try {
+      // 1. 매크로 생성
+      const macro = await createMacro(authStore.userId, macroName.value.trim());
 
-    // 새 거래 추가
-    existingTransactions.unshift(transaction);
+      // 2. 출금 단계 추가 (임시로 계좌 정보는 null로 설정)
+      const stepData = {
+        stepOrder: 1,
+        stepType: 'WITHDRAW',
+        amount: parseInt(amount.value) * 10000, // 만원을 원으로 변환
+        currencyCode: 'KRW',
+        sourceAccountNo: null, // 실제로는 사용자 계좌 선택 필요
+        sourceBankCode: null,
+        targetAccountNo: null,
+        targetBankCode: null,
+        note: `출금 매크로 - ${amount.value}만원`,
+      };
 
-    // 로컬스토리지에 저장
-    localStorage.setItem(STORAGE_KEYS.TRANSACTIONS, JSON.stringify(existingTransactions));
+      await addMacroStep(macro.id, stepData);
 
-    showAlert('거래 완료', '출금 거래가 추가되었습니다.');
+      // 폼 초기화
+      amount.value = '';
+      macroName.value = '';
+
+      // 홈으로 이동
+      showAlert('매크로 생성 완료', `"${macro.name}" 매크로가 생성되었습니다.`);
+    } catch (error) {
+      console.error('매크로 생성 오류:', error);
+      showAlert('오류', error.message || '매크로 생성 중 오류가 발생했습니다.');
+    }
   };
 
   const handleModalConfirm = () => {
@@ -92,6 +126,38 @@
       </div>
 
       <h1 class="text-2xl font-bold mb-10">얼마를 뽑으시겠어요?</h1>
+
+      <!-- 매크로 이름 설정 -->
+      <div class="mb-10">
+        <div class="flex items-center justify-between mb-3">
+          <span class="text-sm font-medium text-gray-700">매크로 이름</span>
+          <button
+            @click="toggleMacroNameInput"
+            class="text-sm text-blue-600 hover:text-blue-800 font-medium"
+          >
+            {{ showMacroNameInput ? '기본값 사용' : '직접 설정' }}
+          </button>
+        </div>
+
+        <!-- 매크로 이름 입력 필드 (조건부 표시) -->
+        <div v-if="showMacroNameInput" class="mb-3">
+          <TextInput
+            v-model="macroName"
+            text=""
+            name="macroName"
+            :required="true"
+            type="text"
+            placeholder="예: 월말 출금, 급여 출금"
+          />
+        </div>
+
+        <!-- 기본 매크로 이름 표시 -->
+        <div v-else class="bg-gray-50 rounded-lg p-3">
+          <p class="text-sm text-gray-600">
+            {{ macroName || '금액을 선택하면 자동으로 설정됩니다' }}
+          </p>
+        </div>
+      </div>
 
       <div @click="handleAmountClick" class="cursor-pointer flex items-center gap-3 pb-3">
         <TextInput
@@ -127,7 +193,8 @@
         금액을 입력해주세요
       </div>
 
-      <PrimaryBtn class="w-full py-2" text="거래 추가" @click="handleAddTransaction" />
+      <!-- 액션 버튼 -->
+      <PrimaryBtn class="w-full py-2" text="매크로 생성" @click="handleAddTransaction" />
     </div>
 
     <!-- Number Pad -->

--- a/hyo-banking-mobile/src/views/transaction/ShowQrView.vue
+++ b/hyo-banking-mobile/src/views/transaction/ShowQrView.vue
@@ -1,79 +1,234 @@
 <script setup>
-  import { ref, onMounted } from 'vue';
+  import { ref, onMounted, computed } from 'vue';
   import { useRoute, useRouter } from 'vue-router';
-  import { STORAGE_KEYS } from '@/constants';
-  import GoBackBtn from '@/components/buttons/GoBackBtn.vue';
+  import QRCode from 'qrcode';
+  import BackButton from '@/components/buttons/GoBackBtn.vue';
   import PrimaryBtn from '@/components/buttons/PrimaryBtn.vue';
+  import Modal from '@/components/Modal.vue';
+  import { createQrToken } from '@/apis';
 
   const route = useRoute();
   const router = useRouter();
-  const transaction = ref(null);
 
-  onMounted(() => {
-    loadTransaction();
+  const showModal = ref(false);
+  const modalConfig = ref({
+    title: '',
+    message: '',
+    showCancel: false,
   });
 
-  const loadTransaction = () => {
-    const transactionId = route.params.id;
-    if (!transactionId) return;
+  // 서버에서 받은 데이터
+  const qrData = ref(null);
+  const isLoading = ref(false);
+  const qrCodeUrl = ref('');
 
-    const transactions = JSON.parse(localStorage.getItem(STORAGE_KEYS.TRANSACTIONS) || '[]');
-    transaction.value = transactions.find(t => t.id === transactionId);
+  const macroId = computed(() => route.params.id);
+  const macroName = computed(() => route.query.macroName || '매크로');
+
+  const showAlert = (title, message, showCancel = false) => {
+    modalConfig.value = { title, message, showCancel };
+    showModal.value = true;
   };
 
-  const handleComplete = () => {
+  const handleModalConfirm = () => {
+    showModal.value = false;
     router.push({ name: 'home' });
   };
+
+  const handleModalCancel = () => {
+    showModal.value = false;
+  };
+
+  const handleCopyToken = async () => {
+    try {
+      const jsonString = JSON.stringify(qrData.value, null, 2);
+      await navigator.clipboard.writeText(jsonString);
+      showAlert('복사 완료', 'JSON 데이터가 클립보드에 복사되었습니다.');
+    } catch (error) {
+      console.error('복사 실패:', error);
+      showAlert('오류', '복사에 실패했습니다.');
+    }
+  };
+
+  // QR 코드 생성 (JSON 객체를 문자열로 변환)
+  const generateQRCode = async qrData => {
+    try {
+      const options = {
+        width: 200,
+        margin: 2,
+        color: {
+          dark: '#000000',
+          light: '#FFFFFF',
+        },
+      };
+
+      // JSON 객체를 문자열로 변환
+      const jsonString = JSON.stringify(qrData);
+      qrCodeUrl.value = await QRCode.toDataURL(jsonString, options);
+    } catch (error) {
+      console.error('QR 코드 생성 오류:', error);
+      showAlert('오류', 'QR 코드 생성 중 오류가 발생했습니다.');
+    }
+  };
+
+  // QR 토큰 데이터 로드
+  const loadQrData = async () => {
+    if (!macroId.value) {
+      showAlert('오류', '잘못된 매크로 정보입니다.');
+      router.push({ name: 'home' });
+      return;
+    }
+
+    try {
+      isLoading.value = true;
+
+      // 기존 토큰이 있는지 확인
+      if (route.query.token) {
+        // URL에서 토큰을 받은 경우
+        qrData.value = {
+          macroId: parseInt(macroId.value),
+          qrToken: route.query.token,
+        };
+        await generateQRCode(qrData.value);
+      } else {
+        // 서버에서 새 토큰 생성
+        const response = await createQrToken(macroId.value);
+        qrData.value = response;
+        await generateQRCode(qrData.value);
+      }
+    } catch (error) {
+      console.error('QR 토큰 로드 오류:', error);
+      showAlert('오류', 'QR 토큰을 가져오는 중 오류가 발생했습니다.');
+      router.push({ name: 'home' });
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  const handleRefreshQr = async () => {
+    try {
+      isLoading.value = true;
+      const response = await createQrToken(macroId.value);
+      qrData.value = response;
+      await generateQRCode(qrData.value);
+      showAlert('새로고침 완료', '새 QR 코드가 생성되었습니다.');
+    } catch (error) {
+      console.error('QR 토큰 새로고침 오류:', error);
+      showAlert('오류', 'QR 토큰 새로고침 중 오류가 발생했습니다.');
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  onMounted(() => {
+    loadQrData();
+  });
 </script>
 
 <template>
   <main class="w-full h-full flex flex-col">
-    <!-- 헤더 -->
-    <div class="px-5 pt-10 pb-6">
-      <div class="">
-        <GoBackBtn />
+    <div class="px-5">
+      <div class="pt-10 pb-8">
+        <BackButton />
       </div>
-    </div>
 
-    <!-- QR 코드 표시 -->
-    <div v-if="transaction" class="px-5 flex-1 flex flex-col items-center justify-between">
-      <!-- QR 코드 영역 -->
-      <div class="bg-white rounded-2xl shadow-sm p-8 w-full max-w-sm">
+      <h1 class="text-2xl font-bold mb-2 text-center">매크로 실행</h1>
+      <p class="text-gray-600 text-center mb-8">{{ macroName }}</p>
+
+      <!-- 로딩 상태 -->
+      <div v-if="isLoading" class="bg-white rounded-2xl p-8 shadow-sm mb-6">
         <div class="text-center">
-          <h3 class="text-lg font-semibold text-gray-700 mb-4">QR 코드</h3>
-          <div class="bg-gray-100 rounded-xl p-8 mb-4">
-            <!-- QR 코드 이미지 또는 플레이스홀더 -->
-            <div class="w-48 h-48 mx-auto bg-gray-200 rounded-lg flex items-center justify-center">
-              <div class="text-center text-gray-500">
-                <svg class="w-16 h-16 mx-auto mb-2" fill="currentColor" viewBox="0 0 20 20">
-                  <path
-                    fill-rule="evenodd"
-                    d="M3 4a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm2 2V5h1v1H5zM3 13a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1v-3zm2 2v-1h1v1H5zM13 4a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1V4zm2 2V5h1v1h-1z"
-                    clip-rule="evenodd"
-                  ></path>
-                </svg>
-                <p class="text-sm">QR 코드</p>
-              </div>
-            </div>
-          </div>
-          <p class="text-sm text-gray-500">QR 코드를 스캔하여 거래 정보를 확인하세요</p>
+          <div
+            class="animate-spin rounded-full h-16 w-16 border-b-2 border-blue-600 mx-auto mb-4"
+          ></div>
+          <p class="text-gray-600">QR 코드를 생성하는 중...</p>
         </div>
       </div>
 
-      <!-- 거래 정보 카드 -->
+      <!-- QR 코드 영역 -->
+      <div v-else-if="qrData && qrCodeUrl" class="bg-white rounded-2xl p-8 shadow-sm mb-6">
+        <div class="text-center">
+          <div class="mb-4">
+            <img
+              :src="qrCodeUrl"
+              alt="QR Code"
+              class="mx-auto border-2 border-gray-200 rounded-lg"
+              style="width: 200px; height: 200px"
+            />
+          </div>
 
-      <!-- 완료 버튼 -->
-      <div class="w-full pb-10">
-        <PrimaryBtn class="w-full py-3" text="완료" @click="handleComplete" />
+          <p class="text-sm text-gray-600 mb-4">ATM에서 이 QR 코드를 스캔하세요</p>
+
+          <div class="bg-gray-50 rounded-lg p-3 mb-4">
+            <p class="text-xs text-gray-500 mb-1">QR 코드 데이터 (JSON)</p>
+            <p class="text-sm font-mono break-all">{{ JSON.stringify(qrData, null, 2) }}</p>
+          </div>
+
+          <div class="flex gap-2">
+            <button
+              @click="handleCopyToken"
+              class="flex-1 py-2 bg-gray-200 text-gray-700 rounded-xl font-medium text-sm"
+            >
+              JSON 복사
+            </button>
+            <button
+              @click="handleRefreshQr"
+              :disabled="isLoading"
+              class="flex-1 py-2 bg-blue-100 text-blue-700 rounded-xl font-medium text-sm disabled:opacity-50"
+            >
+              새로고침
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- 에러 상태 -->
+      <div v-else class="bg-red-50 rounded-2xl p-8 shadow-sm mb-6">
+        <div class="text-center">
+          <div class="text-red-600 text-4xl mb-4">⚠️</div>
+          <p class="text-red-800 font-medium mb-2">QR 코드를 불러올 수 없습니다</p>
+          <p class="text-red-600 text-sm">잠시 후 다시 시도해주세요</p>
+        </div>
+      </div>
+
+      <!-- 사용 안내 -->
+      <div class="bg-blue-50 rounded-2xl p-6 mb-6">
+        <h3 class="font-bold text-blue-900 mb-3">📱 사용 방법</h3>
+        <ol class="text-sm text-blue-800 space-y-2">
+          <li>1. ATM에서 "QR 코드 스캔" 메뉴를 선택하세요</li>
+          <li>2. 이 화면의 QR 코드를 스캔하세요</li>
+          <li>3. 매크로가 자동으로 실행됩니다</li>
+          <li>4. QR 코드는 5분 후 만료됩니다</li>
+        </ol>
+      </div>
+
+      <!-- 주의사항 -->
+      <div class="bg-yellow-50 rounded-2xl p-6 mb-6">
+        <h3 class="font-bold text-yellow-900 mb-3">⚠️ 주의사항</h3>
+        <ul class="text-sm text-yellow-800 space-y-1">
+          <li>• QR 코드는 1회만 사용 가능합니다</li>
+          <li>• 타인과 공유하지 마세요</li>
+          <li>• 만료된 코드는 다시 생성해야 합니다</li>
+        </ul>
       </div>
     </div>
 
-    <!-- 거래 정보 없음 -->
-    <div v-else class="px-5 flex-1 flex items-center justify-center">
-      <div class="text-center">
-        <p class="text-gray-500 text-lg">거래 정보를 찾을 수 없습니다.</p>
-        <GoBackBtn text="돌아가기" class="mt-4" />
-      </div>
+    <div class="px-5 pb-10">
+      <PrimaryBtn
+        class="w-full py-3"
+        text="홈으로 돌아가기"
+        @click="() => router.push({ name: 'home' })"
+      />
     </div>
+
+    <!-- Modal -->
+    <Modal
+      :isVisible="showModal"
+      :title="modalConfig.title"
+      :message="modalConfig.message"
+      :showCancel="modalConfig.showCancel"
+      @confirm="handleModalConfirm"
+      @cancel="handleModalCancel"
+    />
   </main>
 </template>

--- a/hyo-banking-mobile/src/views/transaction/TransactionView.vue
+++ b/hyo-banking-mobile/src/views/transaction/TransactionView.vue
@@ -1,121 +1,301 @@
 <script setup>
-  import { ref, onMounted } from 'vue';
+  import { ref, onMounted, nextTick } from 'vue';
   import { useRouter, useRoute } from 'vue-router';
-  import { STORAGE_KEYS, TASK_TYPES } from '@/constants';
-  import { formatDate, formatAmount } from '@/utils/formatters';
+  import { formatDate } from '@/utils/formatters';
   import PrimaryBtn from '@/components/buttons/PrimaryBtn.vue';
   import BackButton from '@/components/buttons/GoBackBtn.vue';
   import Modal from '@/components/Modal.vue';
+  import {
+    getMacro,
+    getMacroSteps,
+    createQrToken,
+    deleteMacro,
+    deleteMacroStep,
+    upsertMacroStep,
+    updateMacro,
+  } from '@/apis';
 
   const router = useRouter();
   const route = useRoute();
-  const transaction = ref(null);
+  const macro = ref(null);
+  const macroSteps = ref([]);
+  const isLoading = ref(false);
   const showDeleteModal = ref(false);
-  const modalConfig = ref({
+  const showStepDeleteModal = ref(false);
+  const stepToDelete = ref(null);
+
+  // 매크로 이름 편집 관련
+  const isEditingName = ref(false);
+  const editingName = ref('');
+
+  // 매크로 삭제 모달 설정
+  const deleteModalConfig = ref({
     title: '',
     message: '',
     showCancel: true,
   });
 
-  onMounted(() => {
-    loadTransaction();
+  // 단계 삭제 모달 설정
+  const stepDeleteModalConfig = ref({
+    title: '',
+    message: '',
+    showCancel: true,
   });
 
-  const loadTransaction = () => {
-    const transactionId = route.params.id;
-    if (!transactionId) return;
+  // 이름 변경 모달 설정
+  const nameChangeModalConfig = ref({
+    title: '',
+    message: '',
+    showCancel: true,
+  });
+  const showNameChangeModal = ref(false);
 
-    const transactions = JSON.parse(localStorage.getItem(STORAGE_KEYS.TRANSACTIONS) || '[]');
-    transaction.value = transactions.find(t => t.id === transactionId);
+  onMounted(() => {
+    loadMacro();
+  });
+
+  const loadMacro = async () => {
+    const macroId = route.params.id;
+    if (!macroId) return;
+
+    try {
+      isLoading.value = true;
+      const [macroData, stepsData] = await Promise.all([getMacro(macroId), getMacroSteps(macroId)]);
+      macro.value = macroData;
+      macroSteps.value = stepsData;
+    } catch (error) {
+      console.error('매크로 로드 오류:', error);
+    } finally {
+      isLoading.value = false;
+    }
   };
 
   const handleDeleteClick = () => {
-    modalConfig.value = {
-      title: '거래 삭제',
-      message: '정말로 이 거래를 삭제하시겠습니까?',
+    deleteModalConfig.value = {
+      title: '매크로 삭제',
+      message: '정말로 이 매크로를 삭제하시겠습니까?',
       showCancel: true,
     };
     showDeleteModal.value = true;
   };
 
-  const handleDeleteConfirm = () => {
-    if (!transaction.value) return;
+  const handleDeleteConfirm = async () => {
+    if (!macro.value) return;
 
-    // 로컬스토리지에서 거래 목록 가져오기
-    const transactions = JSON.parse(localStorage.getItem(STORAGE_KEYS.TRANSACTIONS) || '[]');
+    try {
+      await deleteMacro(macro.value.id);
+      showDeleteModal.value = false;
+      router.push({ name: 'home' });
+    } catch (error) {
+      console.error('매크로 삭제 오류:', error);
+      alert('매크로 삭제 중 오류가 발생했습니다.');
+      showDeleteModal.value = false;
+    }
+  };
 
-    // 해당 거래 제거
-    const updatedTransactions = transactions.filter(t => t.id !== transaction.value.id);
-
-    // 로컬스토리지에 저장
-    localStorage.setItem(STORAGE_KEYS.TRANSACTIONS, JSON.stringify(updatedTransactions));
-
-    // 모달 닫기
-    showDeleteModal.value = false;
-
-    // 홈으로 이동
-    router.push({ name: 'home' });
+  // 작업 추가 페이지로 이동
+  const handleAddStepClick = () => {
+    router.push({
+      name: 'add-step',
+      params: { id: macro.value.id },
+    });
   };
 
   const handleDeleteCancel = () => {
     showDeleteModal.value = false;
   };
 
-  const handleQrClick = () => {
-    if (transaction.value) {
-      router.push({ name: 'show-qr', params: { id: transaction.value.id } });
+  // 단계 삭제 클릭
+  const handleStepDeleteClick = step => {
+    stepToDelete.value = step;
+    stepDeleteModalConfig.value = {
+      title: '단계 삭제',
+      message: `"${getStepTypeText(step.stepType)}" 단계를 삭제하시겠습니까?`,
+      showCancel: true,
+    };
+    showStepDeleteModal.value = true;
+  };
+
+  // 단계 삭제 확인
+  const handleStepDeleteConfirm = async () => {
+    if (!stepToDelete.value || !macro.value) return;
+
+    try {
+      await deleteMacroStep(macro.value.id, stepToDelete.value.stepOrder);
+      showStepDeleteModal.value = false;
+      stepToDelete.value = null;
+
+      // 매크로 단계 다시 로드
+      await loadMacro();
+
+      // 삭제 후 단계 순서 재정렬
+      await reorderSteps();
+
+      alert('단계가 삭제되었습니다.');
+    } catch (error) {
+      console.error('단계 삭제 오류:', error);
+      alert('단계 삭제 중 오류가 발생했습니다.');
+      showStepDeleteModal.value = false;
     }
   };
 
-  const getTransactionIcon = type => {
+  // 단계 순서 재정렬
+  const reorderSteps = async () => {
+    if (!macro.value || macroSteps.value.length === 0) return;
+
+    try {
+      // 단계들을 stepOrder 순으로 정렬
+      const sortedSteps = [...macroSteps.value].sort((a, b) => a.stepOrder - b.stepOrder);
+
+      // 1부터 시작하는 연속된 순서로 재정렬
+      for (let i = 0; i < sortedSteps.length; i++) {
+        const newOrder = i + 1;
+        if (sortedSteps[i].stepOrder !== newOrder) {
+          await upsertMacroStep(macro.value.id, {
+            stepId: sortedSteps[i].id,
+            stepOrder: newOrder,
+            stepType: sortedSteps[i].stepType,
+            amount: sortedSteps[i].amount,
+            currencyCode: sortedSteps[i].currencyCode,
+            sourceAccountNo: sortedSteps[i].sourceAccountNo,
+            sourceBankCode: sortedSteps[i].sourceBankCode,
+            targetAccountNo: sortedSteps[i].targetAccountNo,
+            targetBankCode: sortedSteps[i].targetBankCode,
+            note: sortedSteps[i].note,
+          });
+        }
+      }
+
+      // 매크로 단계 다시 로드
+      await loadMacro();
+    } catch (error) {
+      console.error('단계 순서 재정렬 오류:', error);
+    }
+  };
+
+  // 단계 삭제 취소
+  const handleStepDeleteCancel = () => {
+    showStepDeleteModal.value = false;
+    stepToDelete.value = null;
+  };
+
+  // 매크로 이름 편집 시작
+  const startEditName = () => {
+    if (!macro.value) return;
+    editingName.value = macro.value.name;
+    isEditingName.value = true;
+
+    // 다음 틱에서 입력 필드에 포커스
+    nextTick(() => {
+      const nameInput = document.querySelector('input[ref="nameInput"]');
+      if (nameInput) {
+        nameInput.focus();
+        nameInput.select();
+      }
+    });
+  };
+
+  // 매크로 이름 편집 취소
+  const cancelEditName = () => {
+    isEditingName.value = false;
+    editingName.value = '';
+  };
+
+  // 매크로 이름 저장
+  const saveMacroName = async () => {
+    if (!macro.value || !editingName.value.trim()) {
+      nameChangeModalConfig.value = {
+        title: '오류',
+        message: '매크로 이름을 입력해주세요.',
+        showCancel: false,
+      };
+      showNameChangeModal.value = true;
+      return;
+    }
+
+    try {
+      await updateMacro(macro.value.id, editingName.value.trim(), macro.value.status);
+
+      // 매크로 정보 다시 로드
+      await loadMacro();
+
+      isEditingName.value = false;
+      editingName.value = '';
+
+      nameChangeModalConfig.value = {
+        title: '수정 완료',
+        message: '매크로 이름이 변경되었습니다.',
+        showCancel: false,
+      };
+      showNameChangeModal.value = true;
+    } catch (error) {
+      console.error('매크로 이름 수정 오류:', error);
+      nameChangeModalConfig.value = {
+        title: '오류',
+        message: '매크로 이름 수정 중 오류가 발생했습니다.',
+        showCancel: false,
+      };
+      showNameChangeModal.value = true;
+    }
+  };
+
+  // 이름 변경 모달 확인
+  const handleNameChangeConfirm = () => {
+    showNameChangeModal.value = false;
+  };
+
+  const handleQrClick = async () => {
+    if (!macro.value) return;
+
+    try {
+      const qrToken = await createQrToken(macro.value.id);
+      router.push({
+        name: 'show-qr',
+        params: { id: macro.value.id },
+        query: {
+          token: qrToken.token,
+          macroName: macro.value.name,
+        },
+      });
+    } catch (error) {
+      console.error('QR 토큰 생성 오류:', error);
+      alert('QR 코드 생성 중 오류가 발생했습니다.');
+    }
+  };
+
+  const getStepTypeText = type => {
     switch (type) {
-      case TASK_TYPES.DEPOSIT:
+      case 'BALANCE_CHECK':
+        return '잔액 조회';
+      case 'WITHDRAW':
+        return '출금';
+      case 'DEPOSIT':
+        return '입금';
+      case 'TRANSFER':
+        return '이체';
+      default:
+        return '거래';
+    }
+  };
+
+  const getStepTypeIcon = type => {
+    switch (type) {
+      case 'BALANCE_CHECK':
         return '💰';
-      case TASK_TYPES.WITHDRAW:
+      case 'WITHDRAW':
         return '💸';
-      case TASK_TYPES.TRANSFER:
+      case 'DEPOSIT':
+        return '📥';
+      case 'TRANSFER':
         return '📤';
       default:
         return '💳';
     }
   };
 
-  const getTransactionGradient = type => {
-    switch (type) {
-      case TASK_TYPES.DEPOSIT:
-        return 'bg-gradient-to-br from-green-500 to-green-600';
-      case TASK_TYPES.WITHDRAW:
-        return 'bg-gradient-to-br from-red-500 to-red-600';
-      case TASK_TYPES.TRANSFER:
-        return 'bg-gradient-to-br from-blue-500 to-blue-600';
-      default:
-        return 'bg-gradient-to-br from-gray-500 to-gray-600';
-    }
-  };
-
-  const getTransactionTitle = type => {
-    switch (type) {
-      case TASK_TYPES.DEPOSIT:
-        return '입금';
-      case TASK_TYPES.WITHDRAW:
-        return '출금';
-      case TASK_TYPES.TRANSFER:
-        return '송금';
-      default:
-        return '거래';
-    }
-  };
-
-  const getAmountColor = type => {
-    switch (type) {
-      case TASK_TYPES.DEPOSIT:
-        return 'text-green-600';
-      case TASK_TYPES.WITHDRAW:
-      case TASK_TYPES.TRANSFER:
-        return 'text-red-600';
-      default:
-        return 'text-gray-600';
-    }
+  const formatAmount = amount => {
+    if (!amount) return '0원';
+    return `${(amount / 10000).toLocaleString()}만원`;
   };
 </script>
 
@@ -124,97 +304,182 @@
     <!-- 헤더 -->
     <div class="px-5 pt-10 pb-6">
       <div class="mb-6">
-        <BackButton />
+        <BackButton :handleGoBack="() => router.push({ name: 'home' })" />
       </div>
-      <h1 class="text-2xl font-bold">거래 상세</h1>
+      <h1 class="text-2xl font-bold">매크로 상세</h1>
     </div>
 
-    <!-- 거래 상세 정보 -->
-    <div v-if="transaction" class="px-5 flex-1">
-      <!-- Transaction Type Card -->
-      <div class="bg-white rounded-2xl shadow-sm p-6 mb-6">
+    <!-- 로딩 상태 -->
+    <div v-if="isLoading" class="px-5 flex-1 flex items-center justify-center">
+      <div class="text-center">
+        <p class="text-gray-500 text-lg">매크로 정보를 불러오는 중...</p>
+      </div>
+    </div>
+
+    <!-- 매크로 상세 정보 -->
+    <div v-else-if="macro" class="px-5 flex-1">
+      <!-- 매크로 기본 정보 -->
+      <div class="bg-white rounded-2xl shadow-sm p-6 mb-6 relative">
+        <!-- 이름 변경 버튼 -->
+        <button
+          v-if="!isEditingName"
+          @click="startEditName"
+          class="absolute top-4 right-4 text-blue-600 hover:text-blue-800 transition-colors text-sm font-medium"
+        >
+          이름 변경
+        </button>
+
         <div class="flex items-center justify-center mb-4">
-          <div
-            class="w-16 h-16 rounded-full flex items-center justify-center text-white font-bold text-xl mr-4"
-            :class="getTransactionGradient(transaction.type)"
-          >
-            {{ getTransactionIcon(transaction.type) }}
+          <div class="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mr-4">
+            <span class="text-blue-600 font-bold text-xl">📱</span>
           </div>
-          <div class="text-center">
-            <h2 class="text-xl font-bold text-gray-900">
-              {{ getTransactionTitle(transaction.type) }}
-            </h2>
-            <p class="text-sm text-gray-500">{{ formatDate(transaction.createdAt) }}</p>
+          <div class="text-center flex-1">
+            <!-- 매크로 이름 편집 모드 -->
+            <div v-if="isEditingName" class="flex items-center justify-center gap-2 mb-2">
+              <input
+                v-model="editingName"
+                type="text"
+                class="px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-center"
+                placeholder="매크로 이름을 입력하세요"
+                @keyup.enter="saveMacroName"
+                @keyup.escape="cancelEditName"
+                ref="nameInput"
+              />
+              <button
+                @click="saveMacroName"
+                class="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm"
+                title="저장"
+              >
+                ✓
+              </button>
+              <button
+                @click="cancelEditName"
+                class="px-3 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors text-sm"
+                title="취소"
+              >
+                ✕
+              </button>
+            </div>
+            <!-- 매크로 이름 표시 모드 -->
+            <div v-else class="flex items-center justify-center mb-2">
+              <h2 class="text-xl font-bold text-gray-900">{{ macro.name }}</h2>
+            </div>
+            <p class="text-sm text-gray-500">{{ formatDate(macro.createdAt) }}</p>
           </div>
         </div>
-      </div>
-
-      <!-- 거래 금액 -->
-      <div class="bg-white rounded-2xl shadow-sm p-6 mb-6">
-        <h3 class="text-lg font-semibold text-gray-700 mb-4">거래 금액</h3>
         <div class="text-center">
-          <p class="text-3xl font-bold" :class="getAmountColor(transaction.type)">
-            {{ formatAmount(transaction.amount) }}
-          </p>
+          <span
+            class="text-xs px-3 py-1 rounded-full"
+            :class="{
+              'bg-green-100 text-green-700': macro.status === 'ACTIVE',
+              'bg-yellow-100 text-yellow-700': macro.status === 'DRAFT',
+              'bg-gray-100 text-gray-700': macro.status === 'INACTIVE',
+            }"
+          >
+            {{
+              macro.status === 'DRAFT' ? '작성중' : macro.status === 'ACTIVE' ? '활성' : '비활성'
+            }}
+          </span>
         </div>
       </div>
 
-      <!-- 거래 상세정보 -->
-      <div
-        v-if="transaction.type === TASK_TYPES.TRANSFER"
-        class="bg-white rounded-2xl shadow-sm p-6 mb-6"
-      >
-        <h3 class="text-lg font-semibold text-gray-700 mb-4">거래 정보</h3>
-        <div class="space-y-4">
-          <div class="space-y-3">
-            <div class="flex justify-between items-center py-2 border-b border-gray-100">
-              <span class="text-gray-600">받는 사람</span>
-              <span class="font-medium text-gray-900">{{ transaction.recipientName }}</span>
+      <!-- 매크로 단계들 -->
+      <div class="bg-white rounded-2xl shadow-sm p-6 mb-6">
+        <h3 class="text-lg font-semibold text-gray-700 mb-4">실행 단계</h3>
+        <div v-if="macroSteps.length === 0" class="text-center py-4 text-gray-500">
+          <p>등록된 단계가 없습니다.</p>
+        </div>
+        <div v-else class="space-y-3">
+          <div
+            v-for="(step, index) in macroSteps"
+            :key="step.id"
+            class="flex items-center gap-3 p-3 bg-gray-50 rounded-lg group hover:bg-gray-100 transition-colors"
+          >
+            <div
+              class="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center text-blue-600 font-bold text-sm"
+            >
+              {{ index + 1 }}
             </div>
-            <div class="flex justify-between items-center py-2 border-b border-gray-100">
-              <span class="text-gray-600">은행</span>
-              <span class="font-medium text-gray-900">{{ transaction.bankName }}</span>
+            <div class="flex-1">
+              <div class="flex items-center gap-2 mb-1">
+                <span class="text-lg">{{ getStepTypeIcon(step.stepType) }}</span>
+                <span class="font-medium text-gray-900">{{ getStepTypeText(step.stepType) }}</span>
+              </div>
+              <div v-if="step.amount" class="text-sm text-gray-600">
+                금액: {{ formatAmount(step.amount) }}
+              </div>
+              <div v-if="step.note" class="text-sm text-gray-500">
+                {{ step.note }}
+              </div>
             </div>
-            <div class="flex justify-between items-center py-2">
-              <span class="text-gray-600">계좌번호</span>
-              <span class="font-medium text-gray-900">{{ transaction.accountNumber }}</span>
-            </div>
+            <button
+              @click="handleStepDeleteClick(step)"
+              class="w-6 h-6 bg-red-100 text-red-600 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-red-200"
+              title="단계 삭제"
+            >
+              ×
+            </button>
           </div>
         </div>
       </div>
     </div>
 
-    <!-- No Transaction Found -->
+    <!-- 매크로를 찾을 수 없는 경우 -->
     <div v-else class="px-5 flex-1 flex items-center justify-center">
       <div class="text-center">
-        <p class="text-gray-500 text-lg">거래 정보를 찾을 수 없습니다.</p>
+        <p class="text-gray-500 text-lg">매크로 정보를 찾을 수 없습니다.</p>
         <button
-          @click="handleBack"
-          class="mt-4 px-6 py-2 bg-kb-yellow-200 text-kb-brown-200 rounded-xl font-semibold"
+          @click="() => router.push({ name: 'home' })"
+          class="mt-4 px-6 py-2 bg-blue-600 text-white rounded-xl font-semibold"
         >
-          돌아가기
+          홈으로 돌아가기
         </button>
       </div>
     </div>
 
-    <div class="px-5 flex gap-5 pb-10">
+    <div v-if="macro" class="px-5 flex gap-5 pb-10">
       <button
         @click="handleDeleteClick"
         class="w-full py-2 bg-red-500 text-md font-bold text-red-50 rounded-2xl hover:scale-105 active:scale-95 active:brightness-75 transition cursor-pointer"
       >
         삭제
       </button>
+      <button
+        @click="handleAddStepClick"
+        class="w-full py-2 bg-green-500 text-md font-bold text-green-50 rounded-2xl hover:scale-105 active:scale-95 active:brightness-75 transition cursor-pointer"
+      >
+        작업 추가
+      </button>
       <PrimaryBtn class="w-full py-2" text="QR 만들기" @click="handleQrClick" />
     </div>
 
-    <!-- 삭제 확인 모달 -->
+    <!-- 매크로 삭제 확인 모달 -->
     <Modal
       :isVisible="showDeleteModal"
-      :title="modalConfig.title"
-      :message="modalConfig.message"
-      :showCancel="modalConfig.showCancel"
+      :title="deleteModalConfig.title"
+      :message="deleteModalConfig.message"
+      :showCancel="deleteModalConfig.showCancel"
       @confirm="handleDeleteConfirm"
       @cancel="handleDeleteCancel"
+    />
+
+    <!-- 단계 삭제 확인 모달 -->
+    <Modal
+      :isVisible="showStepDeleteModal"
+      :title="stepDeleteModalConfig.title"
+      :message="stepDeleteModalConfig.message"
+      :showCancel="stepDeleteModalConfig.showCancel"
+      @confirm="handleStepDeleteConfirm"
+      @cancel="handleStepDeleteCancel"
+    />
+
+    <!-- 이름 변경 결과 모달 -->
+    <Modal
+      :isVisible="showNameChangeModal"
+      :title="nameChangeModalConfig.title"
+      :message="nameChangeModalConfig.message"
+      :showCancel="nameChangeModalConfig.showCancel"
+      @confirm="handleNameChangeConfirm"
     />
   </main>
 </template>

--- a/hyo-banking-mobile/src/views/transaction/TransferAmountView.vue
+++ b/hyo-banking-mobile/src/views/transaction/TransferAmountView.vue
@@ -5,16 +5,21 @@
   import PrimaryBtn from '@/components/buttons/PrimaryBtn.vue';
   import GoBackBtn from '@/components/buttons/GoBackBtn.vue';
   import Modal from '@/components/Modal.vue';
-  import { TASK_TYPES, STORAGE_KEYS } from '@/constants';
+  import { MACRO_STEP_TYPES, CURRENCY_CODES } from '@/constants';
   import { useRouter, useRoute } from 'vue-router';
+  import { useAuthStore } from '@/stores/auth';
+  import { createMacro, addMacroStep } from '@/apis';
 
   const router = useRouter();
   const route = useRoute();
+  const authStore = useAuthStore();
 
   const amount = ref('');
   const accountNumber = ref('');
   const bankName = ref('');
   const recipientName = ref('');
+  const macroName = ref('');
+  const showMacroNameInput = ref(false);
   const showNumberPad = ref(false);
   const showModal = ref(false);
   const showAmountError = ref(false);
@@ -81,6 +86,9 @@
 
   const handleAmountSelect = value => {
     amount.value = value;
+    if (!showMacroNameInput.value) {
+      macroName.value = `${recipientName.value}으로 ${value}만원 송금`;
+    }
   };
 
   const showAlert = (title, message, showCancel = false) => {
@@ -88,7 +96,14 @@
     showModal.value = true;
   };
 
-  const handleTransferClick = () => {
+  const toggleMacroNameInput = () => {
+    showMacroNameInput.value = !showMacroNameInput.value;
+    if (!showMacroNameInput.value && amount.value) {
+      macroName.value = `${recipientName.value}으로 ${amount.value}만원 송금`;
+    }
+  };
+
+  const handleTransferClick = async () => {
     if (!amount.value || amount.value === '0') {
       showAmountError.value = true;
       setTimeout(() => {
@@ -97,35 +112,37 @@
       return;
     }
 
-    // 거래 정보 생성
-    const transaction = {
-      id: Date.now().toString(),
-      type: TASK_TYPES.TRANSFER,
-      amount: parseInt(amount.value) * 10000, // 만원을 원으로 변환
-      accountNumber: accountNumber.value,
-      bankName: bankName.value,
-      recipientName: recipientName.value,
-      createdAt: new Date().toISOString(),
-    };
+    if (!macroName.value.trim()) {
+      macroName.value = `${recipientName.value}으로 ${amount.value}만원 송금`;
+    }
 
-    // 기존 거래 목록 가져오기
-    const existingTransactions = JSON.parse(
-      localStorage.getItem(STORAGE_KEYS.TRANSACTIONS) || '[]'
-    );
+    try {
+      const macro = await createMacro(authStore.userId, macroName.value.trim());
+      const stepData = {
+        stepOrder: 1,
+        stepType: MACRO_STEP_TYPES.TRANSFER,
+        amount: parseInt(amount.value) * 10000,
+        currencyCode: CURRENCY_CODES.KRW,
+        sourceAccountNo: null,
+        sourceBankCode: null,
+        targetAccountNo: accountNumber.value,
+        targetBankCode: route.query.bankCode || null,
+        note: `송금 매크로 - ${amount.value}만원 (${recipientName.value})`,
+      };
+      await addMacroStep(macro.id, stepData);
 
-    // 새 거래 추가
-    existingTransactions.unshift(transaction);
-
-    // 로컬스토리지에 저장
-    localStorage.setItem(STORAGE_KEYS.TRANSACTIONS, JSON.stringify(existingTransactions));
-
-    showAlert('거래 완료', '송금 거래가 추가되었습니다.');
+      showAlert('매크로 생성 완료', `"${macro.name}" 매크로가 생성되었습니다.`);
+      amount.value = '';
+      macroName.value = '';
+    } catch (error) {
+      console.error('매크로 생성 오류:', error);
+      showAlert('오류', error.message || '매크로 생성 중 오류가 발생했습니다.');
+    }
   };
 
   const handleModalConfirm = () => {
     showModal.value = false;
-    // 홈으로 이동
-    router.push('/');
+    router.push({ name: 'home' });
   };
 
   const handleModalCancel = () => {
@@ -140,6 +157,34 @@
         <GoBackBtn :handleGoBack="handleBack" />
       </div>
       <h1 class="text-2xl font-bold mb-10">얼마를 송금하시겠어요?</h1>
+
+      <!-- 매크로 이름 설정 -->
+      <div class="mb-10">
+        <div class="flex items-center justify-between mb-3">
+          <span class="text-sm font-medium text-gray-700">매크로 이름</span>
+          <button
+            @click="toggleMacroNameInput"
+            class="text-sm text-blue-600 hover:text-blue-800 font-medium"
+          >
+            {{ showMacroNameInput ? '기본값 사용' : '직접 설정' }}
+          </button>
+        </div>
+        <div v-if="showMacroNameInput" class="mb-3">
+          <TextInput
+            v-model="macroName"
+            text=""
+            name="macroName"
+            :required="true"
+            type="text"
+            placeholder="예: 월말 송금, 용돈 송금"
+          />
+        </div>
+        <div v-else class="bg-gray-50 rounded-lg p-3">
+          <p class="text-sm text-gray-600">
+            {{ macroName || '금액을 선택하면 자동으로 설정됩니다' }}
+          </p>
+        </div>
+      </div>
 
       <!-- 계좌 정보 표시 -->
       <div class="mb-6 p-4 bg-gray-50 rounded-xl">
@@ -187,7 +232,7 @@
         금액을 입력해주세요
       </div>
 
-      <PrimaryBtn class="w-full py-2" text="거래 추가" @click="handleTransferClick" />
+      <PrimaryBtn class="w-full py-2" text="매크로 생성" @click="handleTransferClick" />
     </div>
 
     <!-- Number Pad -->

--- a/hyo-banking-mobile/vite.config.js
+++ b/hyo-banking-mobile/vite.config.js
@@ -13,4 +13,13 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 });


### PR DESCRIPTION
<!--
PR 제목 컨벤션(권장): [type][scope] subject (#issue)
ex) feat(fe): 로그인 캐시 도입 (#123)

type: feat | fix | refactor | perf | test | docs | chore | build | ci | style | revert
scope: fe | be | infra | data | docs
-->

# ✨ 요약
<!-- 1~2줄로 핵심만: 무엇을 왜 바꾸었는지 -->

- 매크로 CRUD 인터페이스 구현

# 🔗 관련 이슈
<!-- Close 키워드를 사용하면 머지 시 자동으로 이슈가 닫힙니다. -->

Close #20

---

## 📦 변경사항(What)

- 매크로 생성, 조회, 수정, 삭제 API 연동
- 출금/입금/송금 매크로 생성 기능 추가
- 매크로 상세 페이지에서 단계 관리 및 QR 생성
- 매크로 이름 인라인 편집 기능
- 단계별 삭제 및 순서 재정렬 기능
- 작업 추가 페이지로 다른 매크로 단계 가져오기
- QR 코드 생성/스캔 예제 페이지 추가
- 모달 기반 사용자 피드백 시스템 구축
- UI/UX 개선 및 일관된 디자인 적용

## 🎯 배경/의도(Why)
- 매크로 기능 CRUD 연동

## 🖼️ 스크린샷 / 동영상 (UI 변경 시)

https://github.com/user-attachments/assets/f8b47488-60b2-4e8d-b783-7d62e4540fe0

---

## 👀 리뷰어 가이드
- 실행해 보시고 피드백 주시는게 편할거 같습니다.

리뷰어: @ckdwlsrh @hessepark @rla-hyun @Ahranah 
작업자: @doongeon 

